### PR TITLE
Added Search module.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/gui/kami/RenderHelper.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/RenderHelper.java
@@ -50,6 +50,38 @@ public class RenderHelper {
         drawArc(x, y, radius, start, end, segments);
     }
 
+    public static void verticalLine(int x, int y, int height) {
+        glBegin(GL_LINE_LOOP);
+        {
+            glVertex2d(0, 0);
+            glVertex2d(0, height);
+        }
+    }
+
+    public static void horizontalLine(int x, int y, int width) {
+        glBegin(GL_LINE_LOOP);
+        {
+            glVertex2d(width, 0);
+            glVertex2d(0, 0);
+        }
+    }
+
+    public static void drawLine(int x, int y, int height, int width, float r, float g, float b, float lineWidth, boolean vertical) {
+        glPushMatrix();
+        glTranslatef(x, y, 0.0F);
+        GL11.glColor3f(r, g, b);
+        GL11.glLineWidth(lineWidth);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        if (vertical) {
+            horizontalLine(x, y, width);
+        } else {
+            verticalLine(x, y, height);
+        }
+        glEnd();
+        glPopMatrix();
+    }
+
     public static void drawOutlinedRoundedRectangle(int x, int y, int width, int height, float radius, float dR, float dG, float dB, float dA, float outlineWidth) {
         drawRoundedRectangle(x, y, width, height, radius);
         glColor4f(dR, dG, dB, dA);

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
@@ -17,24 +17,23 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static java.lang.Math.abs;
 import static me.zeroeightsix.kami.util.ColourUtils.toRGBA;
 import static me.zeroeightsix.kami.util.LogUtil.getCurrentCoord;
 
 @Module.Info(name = "Search", description = "Highlights blocks in the world", category = Module.Category.RENDER)
 public class Search extends Module {
-    private static final String DEFAULT_BLOCK_ESP_CONFIG = "minecraft:portal,minecraft:end_portal_frame,minecraft:bed";
+    private static final String DEFAULT_BLOCK_ESP_CONFIG = "minecraft:portal,minecraft:end_portal_frame,minecraft:bed,";
     private Setting<String> espBlockNames = register(Settings.stringBuilder("blocks").withValue(DEFAULT_BLOCK_ESP_CONFIG).withConsumer((old, value) -> refreshESPBlocksSet(value)).build());
     private Setting<String> espBlockNamesAdd = register(Settings.stringBuilder("add").withValue("").withConsumer((old, value) -> addBlockToSearch(value)).build());
     private Setting<String> espBlockNamesDel = register(Settings.stringBuilder("del").withValue("").withConsumer((old, value) -> removeBlockFromSearch(value)).build());
 
     public void addBlockToSearch(String block) {
-        espBlockNames.setValue(espBlockNames.getValue() + "," + espBlockNamesAdd.getValue());
+        espBlockNames.setValue(espBlockNames.getValue() + block + ",");
         refreshESPBlocksSet(espBlockNames.getValue());
     }
 
     public void removeBlockFromSearch(String block) {
-        espBlockNames.setValue(espBlockNames.getValue().replace(espBlockNamesDel.getValue() + ",", ""));
+        espBlockNames.setValue(espBlockNames.getValue().replace(block + ",", ""));
         refreshESPBlocksSet(espBlockNames.getValue());
     }
 
@@ -133,7 +132,7 @@ public class Search extends Module {
         }
     }
 
-    public class Triplet<T, U, V> {
+    public static class Triplet<T, U, V> {
 
         private final T first;
         private final U second;

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
@@ -1,16 +1,15 @@
 package me.zeroeightsix.kami.module.modules.render;
 
 import me.zeroeightsix.kami.event.events.RenderEvent;
+import me.zeroeightsix.kami.gui.kami.RenderHelper;
 import me.zeroeightsix.kami.module.Module;
 import me.zeroeightsix.kami.setting.Setting;
 import me.zeroeightsix.kami.setting.Settings;
 import me.zeroeightsix.kami.util.GeometryMasks;
 import me.zeroeightsix.kami.util.KamiTessellator;
 import net.minecraft.block.Block;
-import net.minecraft.block.material.MapColor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import org.lwjgl.opengl.GL11;
 
@@ -19,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.lang.Math.abs;
 import static me.zeroeightsix.kami.util.ColourUtils.toRGBA;
 import static me.zeroeightsix.kami.util.LogUtil.getCurrentCoord;
 import static me.zeroeightsix.kami.util.MessageSendHelper.sendChatMessage;
@@ -38,29 +38,39 @@ public class Search extends Module {
     public void removeBlockFromSearch(String block) {
         espBlockNames.setValue(espBlockNames.getValue().replace(espBlockNamesDel.getValue() + ",", ""));
         refreshESPBlocksSet(espBlockNames.getValue());
-        MapColor test = Blocks.CACTUS.blockMapColor;
     }
 
-    private boolean hasMadeBlockArray = false;
     Minecraft mc = Minecraft.getMinecraft();
-    private Set<Block> espBlocks = Collections.synchronizedSet(new HashSet<>());
+    private Set<Block> espBlocks;
 
     @Override
     public void onUpdate() {
-        if (!hasMadeBlockArray) {
+        if (espBlocks == null) {
             refreshESPBlocksSet(espBlockNames.getValue());
         }
         if (mc.player == null) return;
-        if (shouldRun()) new Thread(this::calc).start();
+        if (shouldRun()) new Thread(this::makeChunks).start();
     }
 
     public void onEnable() {
         refreshESPBlocksSet(espBlockNames.getValue());
     }
 
+    private void refreshESPBlocksSet(String v) {
+        espBlocks = Collections.synchronizedSet(new HashSet<>());
+        for (String s : v.split(",")) {
+            String s2 = s.trim();
+            if (!s2.equals("minecraft:air")) {
+                Block block = Block.getBlockFromName(s2);
+                if (block != null)
+                    sendChatMessage(s2);
+                    espBlocks.add(block);
+            }
+        }
+    }
+
     private long startTime = 0;
-    private ArrayList<Search.Triplet<BlockPos, Integer, Integer>> a;
-    boolean doneList = false;
+    private ArrayList<Triplet<BlockPos, Integer, Integer>> a;
 
     private boolean shouldRun() {
         if (startTime == 0)
@@ -72,50 +82,87 @@ public class Search extends Module {
         return false;
     }
 
-    private void calc() {
-        a = new ArrayList<>();
+    private void makeChunks() {
         int[] pcoords = getCurrentCoord(false);
+        a = new ArrayList<>();
         int renderdist = 64;
         BlockPos pos1 = new BlockPos(pcoords[0] - renderdist, 0, pcoords[2] - renderdist);
         BlockPos pos2 = new BlockPos(pcoords[0] + renderdist, 255, pcoords[2] + renderdist);
+        /*BlockPos[][] smallChunks = splitChunk(pos1, pos2);
+        ArrayList<ArrayList<Triplet<BlockPos, Integer, Integer>>> foundBlocks = new ArrayList<>();
+        for (BlockPos[] chunk : smallChunks) {
+            new Thread(() -> foundBlocks.add(findBlocksInCoords(chunk[0], chunk[1]))).start();
+        }*/
+        /*new Thread(() -> */findBlocksInCoords(pos1, pos2);//).start();
+    }
+
+    private BlockPos[][] splitChunk(BlockPos pos1, BlockPos pos2) {
+        int x1 = pos1.getX();
+        int z1 = pos1.getZ();
+        int y1 = pos1.getY();
+        int x2 = pos2.getX();
+        int z2 = pos2.getZ();
+        int y2 = pos2.getY();
+        int xDist = abs(x2 - x1);
+        int yDist = abs(y2 - y1);
+        int zDist = abs(z2 - z1);
+        int nOfChunksX = xDist/16;
+        int nOfChunksY = yDist/16;
+        int nOfChunksZ = zDist/16;
+        int nOfChunks = nOfChunksX * nOfChunksY * nOfChunksZ;
+        int startX = x1;
+        int startY = z1;
+        int startZ = y1;
+        int currentX = x1;
+        int currentY = z1;
+        int currentZ = y1;
+        BlockPos[][] chunks = new BlockPos[nOfChunks][2];
+        int curChunk = 0;
+        for (int p = 0; p < nOfChunksY; p++) {
+            for (int o = 0; o < nOfChunksZ; o++) {
+                for (int u = 0; u < nOfChunksX; u++) {
+                    chunks[curChunk] = new BlockPos[2];
+                    chunks[curChunk][0] = new BlockPos(currentX, currentY, currentZ);
+                    chunks[curChunk][1] = new BlockPos(currentX + 16, currentY + 16, currentZ + 16);
+                    currentX = currentX + 16;
+                    curChunk++;
+                }
+                currentX = startX;
+                currentZ = currentZ + 16;
+            }
+            currentY = startY;
+            currentY = currentY + 16;
+        }
+        return chunks;
+    }
+
+    private void findBlocksInCoords(BlockPos pos1, BlockPos pos2) {
         Iterable<BlockPos> blocks = BlockPos.getAllInBox(pos1, pos2);
+        ArrayList<Triplet<BlockPos, Integer, Integer>> foundBlocks = new ArrayList<>();
         for (BlockPos blockPos : blocks) {
             int side = GeometryMasks.Quad.ALL;
             Block block = mc.world.getBlockState(blockPos).getBlock();
             for (Block b : espBlocks) {
-                if (b == block) {
+                if (block == b) {
                     int c = block.blockMapColor.colorValue;
                     int[] cia = {c>>16,c>>8&255,c&255};
                     int blockColor = toRGBA(cia[0], cia[1], cia[2], 100);
-                    a.add(new Search.Triplet<>(blockPos, blockColor, side));
+                    foundBlocks.add(new Triplet<>(blockPos, blockColor, side));
                 }
             }
         }
-        doneList = true;
-    }
-
-    private void refreshESPBlocksSet(String v) {
-        espBlocks.clear();
-        for (String s : v.split(",")) {
-            String s2 = s.trim();
-            if (s2.equals("minecraft:air")) {
-                Block block = Block.getBlockFromName(s2);
-                if (block != null)
-                    espBlocks.add(block);
-            }
-        }
-        hasMadeBlockArray = true;
+        a = foundBlocks;
     }
 
     @Override
     public void onWorldRender(RenderEvent event) {
-        if (doneList && mc.player != null) {
+        if (a != null) {
             GlStateManager.pushMatrix();
             KamiTessellator.prepare(GL11.GL_QUADS);
-            for (Search.Triplet<BlockPos, Integer, Integer> pair : a)
+            for (Triplet<BlockPos, Integer, Integer> pair : a) {
                 KamiTessellator.drawBox(pair.getFirst(), pair.getSecond(), pair.getThird());
+            }
             KamiTessellator.release();
-
             GlStateManager.popMatrix();
             GlStateManager.enableTexture2D();
         }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
@@ -1,0 +1,142 @@
+package me.zeroeightsix.kami.module.modules.render;
+
+import me.zeroeightsix.kami.event.events.RenderEvent;
+import me.zeroeightsix.kami.module.Module;
+import me.zeroeightsix.kami.setting.Setting;
+import me.zeroeightsix.kami.setting.Settings;
+import me.zeroeightsix.kami.util.GeometryMasks;
+import me.zeroeightsix.kami.util.KamiTessellator;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.MapColor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.math.BlockPos;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static me.zeroeightsix.kami.util.ColourUtils.toRGBA;
+import static me.zeroeightsix.kami.util.LogUtil.getCurrentCoord;
+
+@Module.Info(name = "Search", description = "Highlights blocks in the world", category = Module.Category.RENDER)
+public class Search extends Module {
+    private static final String DEFAULT_BLOCK_ESP_CONFIG = "minecraft:portal,minecraft:end_portal_frame,minecraft:bed";
+    private Setting<String> espBlockNames = register(Settings.stringBuilder("blocks").withValue(DEFAULT_BLOCK_ESP_CONFIG).withConsumer((old, value) -> refreshESPBlocksSet(value)).build());
+    private Setting<String> espBlockNamesAdd = register(Settings.stringBuilder("add").withValue("").withConsumer((old, value) -> addBlockToSearch(value)).build());
+    private Setting<String> espBlockNamesDel = register(Settings.stringBuilder("del").withValue("").withConsumer((old, value) -> removeBlockFromSearch(value)).build());
+
+    public void addBlockToSearch(String block) {
+        espBlockNames.setValue(espBlockNames.getValue() + "," + espBlockNamesAdd.getValue());
+        refreshESPBlocksSet(espBlockNames.getValue());
+    }
+
+    public void removeBlockFromSearch(String block) {
+        espBlockNames.setValue(espBlockNames.getValue().replace(espBlockNamesDel.getValue() + ",", ""));
+        refreshESPBlocksSet(espBlockNames.getValue());
+        MapColor test = Blocks.CACTUS.blockMapColor;
+    }
+
+    private boolean hasMadeBlockArray = false;
+    Minecraft mc = Minecraft.getMinecraft();
+    private Set<Block> espBlocks = Collections.synchronizedSet(new HashSet<>());
+
+    @Override
+    public void onUpdate() {
+        if (!hasMadeBlockArray) {
+            refreshESPBlocksSet(espBlockNames.getValue());
+        }
+        if (mc.player != null) {
+            timeout();
+        }
+    }
+
+    public void onEnable() {
+        refreshESPBlocksSet(espBlockNames.getValue());
+    }
+
+    private static long startTime = 0;
+    ArrayList<Search.Triplet<BlockPos, Integer, Integer>> a;
+    boolean doneList = false;
+
+    private void timeout() {
+        if (startTime == 0)
+            startTime = System.currentTimeMillis();
+        if (startTime + 500 <= System.currentTimeMillis()) { // 1 timeout = 1 second = 1000 ms
+            startTime = System.currentTimeMillis();
+            a = new ArrayList<>();
+            int[] pcoords = getCurrentCoord(false);
+            int renderdist = 32;
+            BlockPos pos1 = new BlockPos(pcoords[0] - renderdist, 0, pcoords[2] - renderdist);
+            BlockPos pos2 = new BlockPos(pcoords[0] + renderdist, 255, pcoords[2] + renderdist);
+            Iterable<BlockPos> blocks = BlockPos.getAllInBox(pos1, pos2);
+            for (BlockPos blockPos : blocks) {
+                int side = GeometryMasks.Quad.ALL;
+                Block block = mc.world.getBlockState(blockPos).getBlock();
+                for (Block b : espBlocks) {
+                    if (b == block) {
+                        int c = block.blockMapColor.colorValue;
+                        int[] cia = {c>>16,c>>8&255,c&255};
+                        int blockColor = toRGBA(cia[0], cia[1], cia[2], 100);
+                        a.add(new Search.Triplet<>(blockPos, blockColor, side));
+                    }
+                }
+            }
+            doneList = true;
+        }
+    }
+
+    private void refreshESPBlocksSet(String v) {
+        espBlocks.clear();
+        for (String s : v.split(",")) {
+            String s2 = s.trim();
+            Block block = Block.getBlockFromName(s2);
+            if (block != null)
+                espBlocks.add(block);
+        }
+        hasMadeBlockArray = true;
+    }
+
+    @Override
+    public void onWorldRender(RenderEvent event) {
+        if (doneList && mc.player != null) {
+            GlStateManager.pushMatrix();
+            KamiTessellator.prepare(GL11.GL_QUADS);
+            for (Search.Triplet<BlockPos, Integer, Integer> pair : a)
+                KamiTessellator.drawBox(pair.getFirst(), pair.getSecond(), pair.getThird());
+            KamiTessellator.release();
+
+            GlStateManager.popMatrix();
+            GlStateManager.enableTexture2D();
+        }
+    }
+
+    public class Triplet<T, U, V> {
+
+        private final T first;
+        private final U second;
+        private final V third;
+
+        public Triplet(T first, U second, V third) {
+            this.first = first;
+            this.second = second;
+            this.third = third;
+        }
+
+        public T getFirst() {
+            return first;
+        }
+
+        public U getSecond() {
+            return second;
+        }
+
+        public V getThird() {
+            return third;
+        }
+    }
+}
+

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
@@ -75,7 +75,7 @@ public class Search extends Module {
     private void calc() {
         a = new ArrayList<>();
         int[] pcoords = getCurrentCoord(false);
-        int renderdist = 32;
+        int renderdist = 64;
         BlockPos pos1 = new BlockPos(pcoords[0] - renderdist, 0, pcoords[2] - renderdist);
         BlockPos pos2 = new BlockPos(pcoords[0] + renderdist, 255, pcoords[2] + renderdist);
         Iterable<BlockPos> blocks = BlockPos.getAllInBox(pos1, pos2);
@@ -98,9 +98,11 @@ public class Search extends Module {
         espBlocks.clear();
         for (String s : v.split(",")) {
             String s2 = s.trim();
-            Block block = Block.getBlockFromName(s2);
-            if (block != null)
-                espBlocks.add(block);
+            if (s2.equals("minecraft:air")) {
+                Block block = Block.getBlockFromName(s2);
+                if (block != null)
+                    espBlocks.add(block);
+            }
         }
         hasMadeBlockArray = true;
     }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Search.java
@@ -72,75 +72,37 @@ public class Search extends Module {
     private boolean shouldRun() {
         if (startTime == 0)
             startTime = System.currentTimeMillis();
-        if (startTime + 200 <= System.currentTimeMillis()) { // 1 timeout = 1 second = 1000 ms
+        if (startTime + 500 <= System.currentTimeMillis()) { // 1 timeout = 1 second = 1000 ms
             startTime = System.currentTimeMillis();
             return true;
         }
         return false;
     }
 
+    boolean doneList = false;
+
     private void makeChunks() {
         doneList = false;
         int[] pcoords = getCurrentCoord(false);
-        int renderdist = 64;
+        int renderdist = mc.gameSettings.renderDistanceChunks * 16;
+        if (renderdist > 80) {
+            renderdist = 80;
+        }
         BlockPos pos1 = new BlockPos(pcoords[0] - renderdist, 0, pcoords[2] - renderdist);
-        BlockPos pos2 = new BlockPos(pcoords[0] + renderdist, 255, pcoords[2] + renderdist);
-        BlockPos[][] smallChunks = splitChunk(pos1, pos2);
+        BlockPos pos2 = new BlockPos(pcoords[0] + renderdist, 256, pcoords[2] + renderdist);
         ArrayList<ArrayList<Triplet<BlockPos, Integer, Integer>>> foundBlocks = new ArrayList<>();
-        foundBlocks.add(findBlocksInCoords(pos1, pos2));
+        foundBlocks.add(findBlocksInCoords(pos1, pos2, espBlocks));
         a = foundBlocks;
         doneList = true;
     }
 
-    private BlockPos[][] splitChunk(BlockPos pos1, BlockPos pos2) {
-        int x1 = pos1.getX();
-        int z1 = pos1.getZ();
-        int y1 = pos1.getY();
-        int x2 = pos2.getX();
-        int z2 = pos2.getZ();
-        int y2 = pos2.getY();
-        int xDist = abs(x2 - x1);
-        int yDist = abs(y2 - y1);
-        int zDist = abs(z2 - z1);
-        int nOfChunksX = xDist/16;
-        int nOfChunksY = yDist/16;
-        int nOfChunksZ = zDist/16;
-        int nOfChunks = nOfChunksX * nOfChunksY * nOfChunksZ;
-        int startX = x1;
-        int startY = z1;
-        int startZ = y1;
-        int currentX = x1;
-        int currentY = z1;
-        int currentZ = y1;
-        BlockPos[][] chunks = new BlockPos[nOfChunks][2];
-        int curChunk = 0;
-        for (int p = 0; p < nOfChunksY; p++) {
-            for (int o = 0; o < nOfChunksZ; o++) {
-                for (int u = 0; u < nOfChunksX; u++) {
-                    chunks[curChunk] = new BlockPos[2];
-                    chunks[curChunk][0] = new BlockPos(currentX, currentY, currentZ);
-                    chunks[curChunk][1] = new BlockPos(currentX + 16, currentY + 16, currentZ + 16);
-                    currentX = currentX + 16;
-                    curChunk++;
-                }
-                currentX = startX;
-                currentZ = currentZ + 16;
-            }
-            currentY = startY;
-            currentY = currentY + 16;
-        }
-        return chunks;
-    }
-
-    boolean doneList = false;
-
-    private ArrayList<Triplet<BlockPos, Integer, Integer>> findBlocksInCoords(BlockPos pos1, BlockPos pos2) {
+    private ArrayList<Triplet<BlockPos, Integer, Integer>> findBlocksInCoords(BlockPos pos1, BlockPos pos2, Set<Block> blocksToFind) {
         Iterable<BlockPos> blocks = BlockPos.getAllInBox(pos1, pos2);
         ArrayList<Triplet<BlockPos, Integer, Integer>> foundBlocks = new ArrayList<>();
         for (BlockPos blockPos : blocks) {
             int side = GeometryMasks.Quad.ALL;
             Block block = mc.world.getBlockState(blockPos).getBlock();
-            for (Block b : espBlocks) {
+            for (Block b : blocksToFind) {
                 if (block == b) {
                     int c = block.blockMapColor.colorValue;
                     int[] cia = {c>>16,c>>8&255,c&255};


### PR DESCRIPTION
Added a search module, highlights blocks in world based on their Minecraft map item colour.

`;set search add <BLOCKNAME>` adds a block to search, if player adds block air, it gets ignored. 
eg: `;set search add minecraft:log`

`;set search del <BLOCKNAME>` removes a block to search.
eg: `;set search del minecraft:log`

`;set search blocks [string]` lists or sets the entire list of blocks. 
eg: `;set search blocks` will return `minecraft:portal,minecraft:end_portal_frame,minecraft:bed,` unless the player has changed the block list.
`;set search blocks minecraft:log,minecraft:crafting_table` will overwrite the list with `minecraft:log,minecraft:crafting_table`.

NOTE: if player adds a none existant block it will show up in the search list but will be ignored.

EDIT: this resolves #495 
