### PR TITLE
MixinMinecraft: Don't redirect the crash report handler, inject instead

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraft.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraft.java
@@ -96,9 +96,10 @@ public class MixinMinecraft {
         info.cancel();
     }
 
-    @Redirect(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;displayCrashReport(Lnet/minecraft/crash/CrashReport;)V"))
-    public void displayCrashReport(Minecraft minecraft, CrashReport crashReport) {
-        save();
+    @Inject(method = "run", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/client/Minecraft;displayCrashReport(Lnet/minecraft/crash/CrashReport;)V", shift = At.Shift.BEFORE))
+    public void displayCrashReport(CallbackInfo _info) {
+       save();
     }
 
     @Inject(method = "shutdown", at = @At("HEAD"))


### PR DESCRIPTION
Previously, the mod was using `@Redirect` to run its `save()` method for saving the configuration upon a crash.  
However, this completely skips the normal crash report handler, which has two major drawbacks:
* When a crash is about to occur, the client freezes instead and never exits;
* If the crash is caused by a compatibility issue, the other mod developers may never see the crash report.

What this PR proposes is to `@Inject` before the call to `displayCrashReport` instead, letting the client exit as normal.

Same as zeroeightysix/KAMI#189