### PR TITLE
Added '.build()' calls to settings lacking this call.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatFilter.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatFilter.java
@@ -33,7 +33,7 @@ import static me.zeroeightsix.kami.util.MessageSendHelper.sendErrorMessage;
 public class ChatFilter extends Module {
     private Setting<Boolean> filterOwn = register(Settings.b("Filter Own", false));
     private Setting<Boolean> filterDMs = register(Settings.b("Filter DMs", false));
-    private Setting<Boolean> hasRunInfo = register(Settings.booleanBuilder("Info").withValue(false).withVisibility(v -> false));
+    private Setting<Boolean> hasRunInfo = register(Settings.booleanBuilder("Info").withValue(false).withVisibility(v -> false).build());
 
     private static List<String> tempLines = new ArrayList<>();
     private static String[] chatFilter;

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/AimBot.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/AimBot.kt
@@ -24,15 +24,15 @@ import kotlin.math.atan2
         category = Module.Category.COMBAT
 )
 class AimBot : Module() {
-    private val range = register(Settings.integerBuilder("Range").withMinimum(4).withMaximum(24).withValue(16))
-    private val useBow = register(Settings.booleanBuilder("Use Bow").withValue(true))
-    private val ignoreWalls = register(Settings.booleanBuilder("Ignore Walls").withValue(true))
-    private val targetPlayers = register(Settings.booleanBuilder("Target Players").withValue(true))
-    private val targetFriends = register(Settings.booleanBuilder("Friends").withValue(false).withVisibility { targetPlayers.value == true })
-    private val targetSleeping = register(Settings.booleanBuilder("Sleeping").withValue(false).withVisibility { targetPlayers.value == true })
-    private val targetMobs = register(Settings.booleanBuilder("Target Mobs").withValue(false))
-    private val targetHostileMobs = register(Settings.booleanBuilder("Hostile").withValue(true).withVisibility { targetMobs.value == true })
-    private val targetPassiveMobs = register(Settings.booleanBuilder("Passive").withValue(false).withVisibility { targetMobs.value == true })
+    private val range = register(Settings.integerBuilder("Range").withMinimum(4).withMaximum(24).withValue(16).build())
+    private val useBow = register(Settings.booleanBuilder("Use Bow").withValue(true).build())
+    private val ignoreWalls = register(Settings.booleanBuilder("Ignore Walls").withValue(true).build())
+    private val targetPlayers = register(Settings.booleanBuilder("Target Players").withValue(true).build())
+    private val targetFriends = register(Settings.booleanBuilder("Friends").withValue(false).withVisibility { targetPlayers.value == true }.build())
+    private val targetSleeping = register(Settings.booleanBuilder("Sleeping").withValue(false).withVisibility { targetPlayers.value == true }.build())
+    private val targetMobs = register(Settings.booleanBuilder("Target Mobs").withValue(false).build())
+    private val targetHostileMobs = register(Settings.booleanBuilder("Hostile").withValue(true).withVisibility { targetMobs.value == true }.build())
+    private val targetPassiveMobs = register(Settings.booleanBuilder("Passive").withValue(false).withVisibility { targetMobs.value == true }.build())
 
     override fun onUpdate() {
         if (KamiMod.MODULE_MANAGER.getModuleT(Aura::class.java).isEnabled) {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/AutoMend.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/AutoMend.kt
@@ -27,7 +27,7 @@ class AutoMend : Module() {
     private val autoThrow = register(Settings.b("Auto Throw", true))
     private val autoSwitch = register(Settings.b("Auto Switch", true))
     private val autoDisable = register(Settings.booleanBuilder("Auto Disable").withValue(false).withVisibility { autoSwitch.value }.build())
-    private val threshold = register(Settings.integerBuilder("Repair %").withMinimum(1).withMaximum(100).withValue(75))
+    private val threshold = register(Settings.integerBuilder("Repair %").withMinimum(1).withMaximum(100).withValue(75).build())
     private val fast = register(Settings.b("FastUse", true))
     private val gui = register(Settings.b("Run in GUIs", false))
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/StashFinder.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/StashFinder.kt
@@ -25,10 +25,10 @@ import net.minecraft.util.math.ChunkPos
 )
 class StashFinder : Module() {
     private val logChests = register(Settings.b("Chests"))
-    private val chestDensity = register(Settings.integerBuilder("Min Chests").withMinimum(1).withMaximum(20).withValue(5))
+    private val chestDensity = register(Settings.integerBuilder("Min Chests").withMinimum(1).withMaximum(20).withValue(5).build())
 
     private val logShulkers = register(Settings.b("Shulkers"))
-    private val shulkerDensity = register(Settings.integerBuilder("Min Shulkers").withMinimum(1).withMaximum(20).withValue(1))
+    private val shulkerDensity = register(Settings.integerBuilder("Min Shulkers").withMinimum(1).withMaximum(20).withValue(1).build())
 
     private val logToChat = register(Settings.b("Log To Chat"))
     private val playSound = register(Settings.b("Play Sound"))

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/PacketCancel.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/PacketCancel.kt
@@ -18,11 +18,11 @@ import net.minecraft.network.play.client.*
 )
 class PacketCancel : Module() {
     private val all = register(Settings.b("All", false))
-    private val packetInput = register(Settings.booleanBuilder("CPacketInput").withValue(true).withVisibility { !all.value })
-    private val packetPlayer = register(Settings.booleanBuilder("CPacketPlayer").withValue(true).withVisibility { !all.value })
-    private val packetEntityAction = register(Settings.booleanBuilder("CPacketEntityAction").withValue(true).withVisibility { !all.value })
-    private val packetUseEntity = register(Settings.booleanBuilder("CPacketUseEntity").withValue(true).withVisibility { !all.value })
-    private val packetVehicleMove = register(Settings.booleanBuilder("CPacketVehicleMove").withValue(true).withVisibility { !all.value })
+    private val packetInput = register(Settings.booleanBuilder("CPacketInput").withValue(true).withVisibility { !all.value }.build())
+    private val packetPlayer = register(Settings.booleanBuilder("CPacketPlayer").withValue(true).withVisibility { !all.value }.build())
+    private val packetEntityAction = register(Settings.booleanBuilder("CPacketEntityAction").withValue(true).withVisibility { !all.value }.build())
+    private val packetUseEntity = register(Settings.booleanBuilder("CPacketUseEntity").withValue(true).withVisibility { !all.value }.build())
+    private val packetVehicleMove = register(Settings.booleanBuilder("CPacketVehicleMove").withValue(true).withVisibility { !all.value }.build())
     private var numPackets = 0
 
     @EventHandler

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/ESP.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/ESP.java
@@ -29,7 +29,7 @@ import static org.lwjgl.opengl.GL11.*;
 )
 public class ESP extends Module {
     private Setting<ESPMode> mode = register(Settings.e("Mode", ESPMode.RECTANGLE));
-    private Setting<Integer> radiusValue = register(Settings.integerBuilder("Width").withMinimum(1).withMaximum(100).withValue(25).withVisibility(v -> mode.getValue().equals(ESPMode.GLOW)));
+    private Setting<Integer> radiusValue = register(Settings.integerBuilder("Width").withMinimum(1).withMaximum(100).withValue(25).withVisibility(v -> mode.getValue().equals(ESPMode.GLOW)).build());
     private Setting<Boolean> players = register(Settings.b("Players", true));
     private Setting<Boolean> animals = register(Settings.b("Animals", false));
     private Setting<Boolean> mobs = register(Settings.b("Mobs", false));

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/HungerOverlay.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/HungerOverlay.kt
@@ -16,9 +16,9 @@ import me.zeroeightsix.kami.setting.Settings
 )
 class HungerOverlay : Module() {
     @JvmField
-    var saturationOverlay: Setting<Boolean> = register(Settings.booleanBuilder("Saturation Overlay").withValue(true))
+    var saturationOverlay: Setting<Boolean> = register(Settings.booleanBuilder("Saturation Overlay").withValue(true).build())
     @JvmField
-    var foodValueOverlay: Setting<Boolean> = register(Settings.booleanBuilder("Food Value Overlay").withValue(true))
+    var foodValueOverlay: Setting<Boolean> = register(Settings.booleanBuilder("Food Value Overlay").withValue(true).build())
     @JvmField
-    var foodExhaustionOverlay: Setting<Boolean> = register(Settings.booleanBuilder("Food Exhaustion Overlay").withValue(true))
+    var foodExhaustionOverlay: Setting<Boolean> = register(Settings.booleanBuilder("Food Exhaustion Overlay").withValue(true).build())
 }


### PR DESCRIPTION
When testing some other changes I noticed certain settings were not saved in my IntelliJ development build, where others worked fine. This is the result of certain Settings.<type>Builders not being built. This pull request hopefully adds the missing .build() calls to all settings lacking this call.