### PR TITLE
NoFall in bucket mode won't use bucket in creative mode or the nether dimension.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/NoFall.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/NoFall.kt
@@ -36,7 +36,7 @@ class NoFall : Module() {
     })
 
     override fun onUpdate() {
-        if (fallMode.value == FallMode.BUCKET && mc.player.fallDistance >= distance.value && !EntityUtil.isAboveWater(mc.player) && System.currentTimeMillis() - last > 100) {
+        if (fallMode.value == FallMode.BUCKET && mc.player.dimension != -1 && !mc.player.capabilities.isCreativeMode && mc.player.fallDistance >= distance.value && !EntityUtil.isAboveWater(mc.player) && System.currentTimeMillis() - last > 100) {
             val posVec = mc.player.positionVector
             val result = mc.world.rayTraceBlocks(posVec, posVec.add(0.0, -5.33, 0.0), true, true, false)
             if (result != null && result.typeOfHit == RayTraceResult.Type.BLOCK) {


### PR DESCRIPTION
This prevents the NoFall module in bucket mode from using a water bucket when the player is in creative mode or in the nether. 
Using the bucket in these situations served no purpose and could actually do more harm than good, as it could destroy torches/grass/decoration while building in creative mode, and would simply waste the bucket in the nether dimension.