### PR TITLE
Fixed an error being raised in 'all' fastuse mode while the player is a spectator.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
@@ -35,7 +35,7 @@ class Fastuse : Module() {
     override fun onUpdate() {
         if (mc.player == null) return
 
-        if (all.value || bow.value && mc.player.heldItemMainhand.getItem() is ItemBow && mc.player.isHandActive && mc.player.itemInUseMaxCount >= 3) {
+        if (!mc.player.isSpectator && (all.value || bow.value && mc.player.heldItemMainhand.getItem() is ItemBow && mc.player.isHandActive && mc.player.itemInUseMaxCount >= 3)) {
             mc.player.connection.sendPacket(CPacketPlayerDigging(CPacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos.ORIGIN, mc.player.horizontalFacing))
             mc.player.connection.sendPacket(CPacketPlayerTryUseItem(mc.player.activeHand))
             mc.player.stopActiveHand()


### PR DESCRIPTION
When in spectator mode, setting fastuse to 'all' will result in the following error:
Java.lang.IllegalArgumentException: Invalid hand null
This pull request fixes this by not executing any fastuse code while in spectator mode.