### PR TITLE
FastUse bow bugfix and feature implementation.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
@@ -24,7 +24,7 @@ class Fastuse : Module() {
     private val delay = register(Settings.integerBuilder("Delay").withMinimum(0).withMaximum(20).withValue(0).build())
     private val all = register(Settings.b("All", false))
     private val bow = register(Settings.booleanBuilder().withName("Bow").withValue(true).withVisibility { !all.value }.build())
-    private val chargeState = register(Settings.integerBuilder("Fire bow on charge state").withMinimum(0).withMaximum(20).withValue(3).build())
+    private val chargeState = register(Settings.integerBuilder("Bow Charge").withMinimum(0).withMaximum(20).withValue(3).withVisibility { all.value || bow.value }.build())
     private val expBottles = register(Settings.booleanBuilder().withName("Exp Bottles").withValue(true).withVisibility { !all.value }.build())
     private val endCrystals = register(Settings.booleanBuilder().withName("End Crystals").withValue(true).withVisibility { !all.value }.build())
     private val fireworks = register(Settings.booleanBuilder().withName("Fireworks").withValue(false).withVisibility { !all.value }.build())

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
@@ -33,9 +33,9 @@ class Fastuse : Module() {
     }
 
     override fun onUpdate() {
-        if (mc.player == null) return
+        if (mc.player == null || mc.player.isSpectator) return
 
-        if (!mc.player.isSpectator && (all.value || bow.value && mc.player.heldItemMainhand.getItem() is ItemBow && mc.player.isHandActive && mc.player.itemInUseMaxCount >= 3)) {
+        if ((all.value || bow.value) && mc.player.heldItemMainhand.getItem() is ItemBow && mc.player.isHandActive && mc.player.itemInUseMaxCount >= 3) {
             mc.player.connection.sendPacket(CPacketPlayerDigging(CPacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos.ORIGIN, mc.player.horizontalFacing))
             mc.player.connection.sendPacket(CPacketPlayerTryUseItem(mc.player.activeHand))
             mc.player.stopActiveHand()

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/Fastuse.kt
@@ -24,6 +24,7 @@ class Fastuse : Module() {
     private val delay = register(Settings.integerBuilder("Delay").withMinimum(0).withMaximum(20).withValue(0).build())
     private val all = register(Settings.b("All", false))
     private val bow = register(Settings.booleanBuilder().withName("Bow").withValue(true).withVisibility { !all.value }.build())
+    private val chargeState = register(Settings.integerBuilder("Fire bow on charge state").withMinimum(0).withMaximum(20).withValue(3).build())
     private val expBottles = register(Settings.booleanBuilder().withName("Exp Bottles").withValue(true).withVisibility { !all.value }.build())
     private val endCrystals = register(Settings.booleanBuilder().withName("End Crystals").withValue(true).withVisibility { !all.value }.build())
     private val fireworks = register(Settings.booleanBuilder().withName("Fireworks").withValue(false).withVisibility { !all.value }.build())
@@ -35,7 +36,7 @@ class Fastuse : Module() {
     override fun onUpdate() {
         if (mc.player == null || mc.player.isSpectator) return
 
-        if ((all.value || bow.value) && mc.player.heldItemMainhand.getItem() is ItemBow && mc.player.isHandActive && mc.player.itemInUseMaxCount >= 3) {
+        if ((all.value || bow.value) && mc.player.heldItemMainhand.getItem() is ItemBow && mc.player.isHandActive && mc.player.itemInUseMaxCount >= chargeState.value) {
             mc.player.connection.sendPacket(CPacketPlayerDigging(CPacketPlayerDigging.Action.RELEASE_USE_ITEM, BlockPos.ORIGIN, mc.player.horizontalFacing))
             mc.player.connection.sendPacket(CPacketPlayerTryUseItem(mc.player.activeHand))
             mc.player.stopActiveHand()


### PR DESCRIPTION
This implements a 'chargeState' setting that allows the user to set the minimum chargeState required to shoot a bow, as requested in issue #799. The game hasn't used the described "1, 2, 3" state functionality anymore since version 1.9 however, so this instead gives the full range of minimum to max strength.
While working on this I noticed the 'all' mode ignored this entirely due to how the conditional was formatted, so I fixed that as well.