### PR TITLE
Some updates to the AntiSpam module.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
@@ -292,7 +292,7 @@ class AntiSpam : Module() {
                 "i just.*thanks to",
                 "i just.*using")
         val SPECIAL_BEGINNING = arrayOf(
-                "^[.,/?!()\\[\\]{}<>|\\-+=\\\\]")
+                "^[.,/?!()\\[\\]{}<|\\-+=\\\\]")
         val SPECIAL_ENDING = arrayOf(
                 "[/@#^()\\[\\]{}<>|\\-+=\\\\]$")
     }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
@@ -144,7 +144,6 @@ class AntiSpam : Module() {
             put(greenText, FilterPatterns.GREEN_TEXT)
             put(specialCharBegin, FilterPatterns.SPECIAL_BEGINNING)
             put(specialCharEnding, FilterPatterns.SPECIAL_ENDING)
-            put(specialCharBegin, FilterPatterns.SPECIAL_BEGINNING)
             put(ownsMeAndAll, FilterPatterns.OWNS_ME_AND_ALL)
             put(iJustThanksTo, FilterPatterns.I_JUST_THANKS_TO)
             put(numberSuffix, FilterPatterns.NUMBER_SUFFIX)

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
@@ -62,7 +62,7 @@ class AntiSpam : Module() {
     }
 
     private enum class ShowBlocked {
-        NONE, LOG_FILE, CHAT
+        NONE, LOG_FILE, CHAT, BOTH
     }
 
     @EventHandler
@@ -118,7 +118,7 @@ class AntiSpam : Module() {
             messageHistory!![message] = System.currentTimeMillis()
 
             if (isDuplicate) {
-                if (showBlocked.value == ShowBlocked.CHAT) MessageSendHelper.sendChatMessage(chatName + "Duplicate: " + message) else if (showBlocked.value == ShowBlocked.LOG_FILE) KamiMod.log.info(chatName + "Duplicate: " + message)
+                if (showBlocked.value == ShowBlocked.CHAT || showBlocked.value == ShowBlocked.BOTH) MessageSendHelper.sendChatMessage(chatName + "Duplicate: " + message) else if (showBlocked.value == ShowBlocked.LOG_FILE) KamiMod.log.info(chatName + "Duplicate: " + message)
             }
         }
         return false
@@ -297,6 +297,7 @@ class AntiSpam : Module() {
     }
 
     private fun sendResult(name: String, message: String) {
-        if (showBlocked.value == ShowBlocked.CHAT) MessageSendHelper.sendChatMessage("$chatName$name: $message") else if (showBlocked.value == ShowBlocked.LOG_FILE) KamiMod.log.info("$chatName$name: $message")
+        if (showBlocked.value == ShowBlocked.CHAT || showBlocked.value == ShowBlocked.BOTH) MessageSendHelper.sendChatMessage("$chatName$name: $message")
+        if (showBlocked.value == ShowBlocked.LOG_FILE || showBlocked.value == ShowBlocked.BOTH) KamiMod.log.info("$chatName$name: $message")
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
@@ -54,6 +54,7 @@ class AntiSpam : Module() {
     private val webLinks = register(Settings.booleanBuilder("Web Links").withValue(false).withVisibility { p.value == Page.TWO }.build())
     private val filterOwn = register(Settings.booleanBuilder("Filter Own").withValue(false).withVisibility { p.value == Page.TWO }.build())
     private val filterDMs = register(Settings.booleanBuilder("Filter DMs").withValue(false).withVisibility { p.value == Page.TWO }.build())
+    private val filterServer = register(Settings.booleanBuilder("Filter server").withValue(false).withVisibility { p.value == Page.TWO }.build())
     private val showBlocked = register(Settings.enumBuilder(ShowBlocked::class.java).withName("Show Blocked").withValue(ShowBlocked.LOG_FILE).withVisibility { p.value == Page.TWO }.build())
     private var messageHistory: ConcurrentHashMap<String, Long>? = null
 
@@ -91,7 +92,7 @@ class AntiSpam : Module() {
     private fun isSpam(message: String): Boolean {
         /* Quick bandaid fix for mc.player being null when the module is being registered, so don't register it with the map */
         val ownMessage = "^<" + mc.player.name + "> "
-        return if (!filterOwn.value && isOwn(ownMessage, message) || MessageDetectionHelper.isDirect(!filterDMs.value, message) || MessageDetectionHelper.isDirectOther(!filterDMs.value, message)) {
+        return if (!filterOwn.value && isOwn(ownMessage, message) || MessageDetectionHelper.isDirect(!filterDMs.value, message) || MessageDetectionHelper.isDirectOther(!filterDMs.value, message) || MessageDetectionHelper.isQueue(!filterServer.value, message) || MessageDetectionHelper.isRestart(!filterServer.value, message)) {
             false
         } else {
             detectSpam(removeUsername(message))

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
@@ -119,7 +119,8 @@ class AntiSpam : Module() {
             messageHistory!![message] = System.currentTimeMillis()
 
             if (isDuplicate) {
-                if (showBlocked.value == ShowBlocked.CHAT || showBlocked.value == ShowBlocked.BOTH) MessageSendHelper.sendChatMessage(chatName + "Duplicate: " + message) else if (showBlocked.value == ShowBlocked.LOG_FILE) KamiMod.log.info(chatName + "Duplicate: " + message)
+                if (showBlocked.value == ShowBlocked.CHAT || showBlocked.value == ShowBlocked.BOTH) MessageSendHelper.sendChatMessage(chatName + "Duplicate: " + message)
+                if (showBlocked.value == ShowBlocked.LOG_FILE || showBlocked.value == ShowBlocked.BOTH) KamiMod.log.info(chatName + "Duplicate: " + message)
             }
         }
         return false

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/AntiSpam.kt
@@ -91,7 +91,7 @@ class AntiSpam : Module() {
     private fun isSpam(message: String): Boolean {
         /* Quick bandaid fix for mc.player being null when the module is being registered, so don't register it with the map */
         val ownMessage = "^<" + mc.player.name + "> "
-        return if (!filterOwn.value && isOwn(ownMessage, message) || MessageDetectionHelper.isDirect(filterDMs.value, message) || MessageDetectionHelper.isDirectOther(filterDMs.value, message)) {
+        return if (!filterOwn.value && isOwn(ownMessage, message) || MessageDetectionHelper.isDirect(!filterDMs.value, message) || MessageDetectionHelper.isDirectOther(!filterDMs.value, message)) {
             false
         } else {
             detectSpam(removeUsername(message))


### PR DESCRIPTION
This pull request:
- Removes a duplicate line from the code.
- Adds a 'both' option for logging spam messages to chat and file.
- Inverts the 'filterDMs' setting to now filter spam when turned on.
- Adds a 'filterServer' setting that will filter Server messages when turned on, and leave them be otherwise.
- Removes the > character from the SPECIAL_BEGINNINGS regex to make the greenText setting work on its own.