### PR TITLE
Improved Aura and fixed a bug with Packet Cancel

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/Aura.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/Aura.kt
@@ -38,6 +38,7 @@ class Aura : Module() {
     private val prefer = register(Settings.e<HitMode>("Prefer", HitMode.SWORD))
     private val autoTool = register(Settings.b("Auto Weapon", true))
     private val sync = register(Settings.b("TPS Sync", false))
+    private val disableOnDeath = register(Settings.b("Disable On Death", false))
     private var waitCounter = 0
 
     enum class HitMode {
@@ -49,7 +50,10 @@ class Aura : Module() {
     }
 
     override fun onUpdate() {
-        if (mc.player == null || mc.player.isDead) return
+        if (mc.player == null || mc.player.isDead) {
+            if (disableOnDeath.value) disable()
+            return
+        }
 
         val autoWaitTick = 20.0f - LagCompensator.INSTANCE.tickRate
         val canAttack = mc.player.getCooledAttackStrength(if (sync.value) -autoWaitTick else 0.0f) >= 1

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/PacketCancel.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/PacketCancel.kt
@@ -27,6 +27,9 @@ class PacketCancel : Module() {
 
     @EventHandler
     private val sendListener = Listener(EventHook { event: PacketEvent.Send ->
+        if (mc.player == null) {
+            return@EventHook
+        }
         if (all.value
                 ||
                 packetInput.value && event.packet is CPacketInput


### PR DESCRIPTION
**Describe the pull**
Fixes being unable to rejoin if you left packet cancel set to all and enabled, adds an option to disable Aura on death.

**Describe how this pull is helpful**
See above 

**Additional context**
No
