### PR TITLE
Fixed fullbright only working if transition is on.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Brightness.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Brightness.java
@@ -48,6 +48,8 @@ public class Brightness extends Module {
             }
 
             inTransition = true;
+        } else {
+            currentBrightness = isEnabled() ? 1 : 0;
         }
     }
 


### PR DESCRIPTION
The fullbright module has a 'transition' setting, which gradually transitions from dark to light and light to dark when turning the module on or off.
When transition is off, a user would expect the brightness to transition instantly, but instead it does nothing, which is fixed by this pull request.