### PR TITLE
Some ElytraReplace changes.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -31,7 +31,12 @@ class ElytraReplace : Module() {
             return
         }
 
-        elytraCount = InfoOverlay.getItems(Items.ELYTRA) + InfoOverlay.getArmor(Items.ELYTRA)
+        elytraCount = 0
+        for (i in 0..44) {
+            if (mc.player.inventory.getStackInSlot(i).getItem() === Items.ELYTRA && !isBroken(i)) {
+                elytraCount += 1
+            }
+        }
         val chestplateCount = InfoOverlay.getItems(Items.DIAMOND_CHESTPLATE) + InfoOverlay.getArmor(Items.DIAMOND_CHESTPLATE)
 
         if (currentlyMovingElytra) {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -5,6 +5,7 @@ import me.zeroeightsix.kami.module.Module
 import me.zeroeightsix.kami.setting.Settings
 import me.zeroeightsix.kami.util.MessageSendHelper
 import net.minecraft.client.audio.PositionedSoundRecord
+import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.init.Items
 import net.minecraft.init.SoundEvents
 import net.minecraft.inventory.ClickType
@@ -19,6 +20,7 @@ import net.minecraft.inventory.ClickType
         category = Module.Category.MOVEMENT
 )
 class ElytraReplace : Module() {
+    private val inventoryMode = register(Settings.b("Inventory", false))
     private val autoChest = register(Settings.b("Auto Chest", false))
     private val elytraFlightCheck = register(Settings.b("ElytraFlight Check", true))
     private val logToChat = register(Settings.booleanBuilder("Missing Warning").withValue(false).build())
@@ -32,7 +34,7 @@ class ElytraReplace : Module() {
     private var chestplateCount = 0
 
     override fun onUpdate() {
-        if (mc.player == null) return
+        if (mc.player == null || (!inventoryMode.value && mc.currentScreen is GuiContainer)) return
 
         elytraCount = 0
         for (i in 0..44) {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -2,9 +2,7 @@ package me.zeroeightsix.kami.module.modules.movement
 
 import me.zeroeightsix.kami.KamiMod
 import me.zeroeightsix.kami.module.Module
-import me.zeroeightsix.kami.module.modules.client.InfoOverlay
 import me.zeroeightsix.kami.setting.Settings
-import me.zeroeightsix.kami.util.MathsUtils
 import net.minecraft.client.gui.inventory.GuiContainer
 import net.minecraft.init.Items
 import net.minecraft.inventory.ClickType
@@ -119,7 +117,7 @@ class ElytraReplace : Module() {
         return if (mc.player.inventory.getStackInSlot(i).maxDamage == 0) {
             false
         } else {
-            100 * mc.player.inventory.getStackInSlot(i).getItemDamage() / mc.player.inventory.getStackInSlot(i).maxDamage > MathsUtils.reverseNumber(threshold.value, 1, 100)
+            (100 * mc.player.inventory.getStackInSlot(i).getItemDamage() / mc.player.inventory.getStackInSlot(i).maxDamage) + threshold.value >= 100
         }
     }
 
@@ -127,7 +125,7 @@ class ElytraReplace : Module() {
         return if (mc.player.inventory.armorInventory[i].maxDamage == 0) {
             false
         } else {
-            100 * mc.player.inventory.armorInventory[i].getItemDamage() / mc.player.inventory.armorInventory[i].maxDamage > MathsUtils.reverseNumber(threshold.value, 1, 100)
+            (100 * mc.player.inventory.armorInventory[i].getItemDamage() / mc.player.inventory.armorInventory[i].maxDamage) + threshold.value >= 100
         }
     }
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -25,6 +25,7 @@ class ElytraReplace : Module() {
     private var currentlyMovingElytra = false
     private var currentlyMovingChestplate = false
     private var elytraCount = 0
+    private var chestplateCount = 0
 
     override fun onUpdate() {
         if (!inventoryMode.value && mc.currentScreen is GuiContainer) {
@@ -35,9 +36,10 @@ class ElytraReplace : Module() {
         for (i in 0..44) {
             if (mc.player.inventory.getStackInSlot(i).getItem() === Items.ELYTRA && !isBroken(i)) {
                 elytraCount += 1
+            } else if (mc.player.inventory.getStackInSlot(i).getItem() === Items.DIAMOND_CHESTPLATE && !isBroken(i)) {
+                chestplateCount += 1
             }
         }
-        val chestplateCount = InfoOverlay.getItems(Items.DIAMOND_CHESTPLATE) + InfoOverlay.getArmor(Items.DIAMOND_CHESTPLATE)
 
         if (currentlyMovingElytra) {
             mc.playerController.windowClick(0, 6, 0, ClickType.PICKUP, mc.player)

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -45,9 +45,7 @@ class ElytraReplace : Module() {
             mc.playerController.windowClick(0, 6, 0, ClickType.PICKUP, mc.player)
             currentlyMovingElytra = false
             return
-        }
-
-        if (currentlyMovingChestplate) {
+        } else if (currentlyMovingChestplate) {
             mc.playerController.windowClick(0, 6, 0, ClickType.PICKUP, mc.player)
             currentlyMovingChestplate = false
             return
@@ -70,9 +68,7 @@ class ElytraReplace : Module() {
                 mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
                 currentlyMovingElytra = true
                 return
-            }
-
-            if (!(mc.player.inventory.armorInventory[2].getItem() === Items.DIAMOND_CHESTPLATE)) {
+            } else if (!(mc.player.inventory.armorInventory[2].getItem() === Items.DIAMOND_CHESTPLATE)) {
                 for (i in 0..44) {
                     if (mc.player.inventory.getStackInSlot(i).getItem() === Items.DIAMOND_CHESTPLATE) {
                         slot = i

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -82,9 +82,7 @@ class ElytraReplace : Module() {
                 mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
                 return
             }
-        }
-
-        if (!onGround() && passElytraFlightCheck()) {
+        } else if (passElytraFlightCheck()) {
             var slot = -420
 
             if (elytraCount == 0) {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraReplace.kt
@@ -88,29 +88,21 @@ class ElytraReplace : Module() {
             }
 
             // if there's no elytra, or it's broken
-            if (mc.player.inventory.armorInventory[2].isEmpty() || isBrokenArmor(2)) {
+            if (!(mc.player.inventory.armorInventory[2].getItem() === Items.ELYTRA) || isBrokenArmor(2)) {
                 for (i in 0..44) {
                     if (mc.player.inventory.getStackInSlot(i).getItem() === Items.ELYTRA && !isBroken(i)) {
                         slot = i
                         break
                     }
                 }
-                mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
-                currentlyMovingElytra = true
-                return
-            }
-
-            // if it's not an elytra, or it's a broken elytra
-            if (!(mc.player.inventory.armorInventory[2].getItem() === Items.ELYTRA) || (mc.player.inventory.armorInventory[2].getItem() === Items.ELYTRA && isBrokenArmor(2))) {
-                for (i in 0..44) {
-                    if (mc.player.inventory.getStackInSlot(i).getItem() === Items.ELYTRA && !isBroken(i)) {
-                        slot = i
-                        break
-                    }
+                if (mc.player.inventory.armorInventory[2].isEmpty()) {
+                    mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
+                    currentlyMovingElytra = true
+                } else {
+                    mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
+                    mc.playerController.windowClick(0, 6, 0, ClickType.PICKUP, mc.player)
+                    mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
                 }
-                mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
-                mc.playerController.windowClick(0, 6, 0, ClickType.PICKUP, mc.player)
-                mc.playerController.windowClick(0, if (slot < 9) slot + 36 else slot, 0, ClickType.PICKUP, mc.player)
             }
         }
     }


### PR DESCRIPTION
This pull request does the following:
- elytraCount and chestplateCount are now based on items meeting the set threshold, not all items.
- Cleaned up some conditionals that will result in less checks and code execution overall.
-  Added a 'logToChat' function that tells you when you are running out of elytras, with an optional playSound setting and an adjustable logThreshold.

These new features come in handy on long journeys when you aren't paying much attention to your inventory or GUI.