### PR TITLE
Fix customsize #tunnel if AutoTunnel settings are default

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoTunnel.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoTunnel.kt
@@ -44,7 +44,15 @@ class AutoTunnel : Module() {
     }
 
     private fun sendTunnel() {
-        val current = arrayOf("tunnel", height.value.toString(), width.value.toString(), "1000000")
+        // fixed *censored* customsize tunnel if settings are default --pNoName
+        // im sorry for *censored* *censored* *censored* code im new to java i came from c++
+        var current = arrayOf("")
+        if (height.value == 2 && width.value == 1) {
+            current = arrayOf("tunnel")
+        }
+        else {
+            current = arrayOf("tunnel", height.value.toString(), width.value.toString(), "1000000")
+        }
 
         if (!current.contentEquals(lastCommand)) {
             lastCommand = current

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoTunnel.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoTunnel.kt
@@ -12,6 +12,7 @@ import me.zeroeightsix.kami.util.MessageSendHelper
 
 /**
  * @author dominikaaaa
+ * Updated by pNoName on 25/05/20
  */
 @Module.Info(
         name = "AutoTunnel",
@@ -44,8 +45,6 @@ class AutoTunnel : Module() {
     }
 
     private fun sendTunnel() {
-        // fixed *censored* customsize tunnel if settings are default --pNoName
-        // im sorry for *censored* *censored* *censored* code im new to java i came from c++
         var current = arrayOf("")
         if (height.value == 2 && width.value == 1) {
             current = arrayOf("tunnel")


### PR DESCRIPTION
**Describe the pull**
So actually customsize #tunnel is kinda *censored* so I decided to make kami use default #tunnel command without any customizations etc

**Describe how this pull is helpful**
It is useful because as I said #tunnel is better than #tunnel 2 1 1000, you can test it yourself and see the big difference

**Additional context**
Sorry for bad code im new in java/kotlin
:nojava: :nokotlin:
