### PR TITLE
Ignore friends option for VisualRange

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
@@ -41,7 +41,7 @@ class VisualRange : Module() {
 
         if (tickPlayerList.size > 0) {
             for (playerName in tickPlayerList) {
-                if ((playerName == mc.player.name) || (Friends.isFriend(playerName) && !friends.value)) continue
+                if ((playerName == mc.player.name) || (!friends.value && Friends.isFriend(playerName))) continue
 
                 if (!knownPlayers!!.contains(playerName)) {
                     knownPlayers!!.add(playerName)

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
@@ -41,8 +41,7 @@ class VisualRange : Module() {
 
         if (tickPlayerList.size > 0) {
             for (playerName in tickPlayerList) {
-                if (playerName == mc.player.name) continue
-                if (Friends.isFriend(playerName) && !friends.value) continue
+                if ((playerName == mc.player.name) || (Friends.isFriend(playerName) && !friends.value)) continue
 
                 if (!knownPlayers!!.contains(playerName)) {
                     knownPlayers!!.add(playerName)

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
@@ -25,6 +25,7 @@ import java.util.*
 class VisualRange : Module() {
     private val playSound = register(Settings.b("Play Sound", false))
     private val leaving = register(Settings.b("Count Leaving", false))
+    private val friends = register(Settings.b("Friends", true))
     private val uwuAura = register(Settings.b("UwU Aura", false))
     private val logToFile = register(Settings.b("Log To File", false))
 
@@ -41,6 +42,7 @@ class VisualRange : Module() {
         if (tickPlayerList.size > 0) {
             for (playerName in tickPlayerList) {
                 if (playerName == mc.player.name) continue
+                if (Friends.isFriend(playerName) && !friends.value) continue
 
                 if (!knownPlayers!!.contains(playerName)) {
                     knownPlayers!!.add(playerName)


### PR DESCRIPTION
Please see #907 for more details.

I chose to have the setting called friends, have friends included if the option is true and default the option to true so as not to require change to existing configs, and to match the labeling/logic of Tracers.