### PR TITLE
Greatly improved ElytraFlight and added Space trigger

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
@@ -192,6 +192,7 @@ class ElytraFlight : Module() {
     })
 
     private fun lookBoost() {
+        if (mc.player.movementInput.moveForward > 0 && mc.player.movementInput.jump && spaceBarTrigger.value && mc.player.rotationPitch > -10) mc.player.rotationPitch = -10f
         val readyToBoost = mc.player.movementInput.moveForward > 0 && ((mc.player.movementInput.jump && spaceBarTrigger.value) || !spaceBarTrigger.value) && mc.player.rotationPitch <= -10
         val shouldAutoBoost = !autoBoost.value || ((mc.player.motionY >= (-fallSpeedControl.value) && sqrt(mc.player.motionX * mc.player.motionX + mc.player.motionZ * mc.player.motionZ) >= 0.8) || (mc.player.motionY >= 1))
         if ((readyToBoost && shouldAutoBoost) != isBoosting) mc.player.rotationPitch -= 0.0001f /*Tried with sending rotation packet, doesn't work on 2B*/

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
@@ -14,15 +14,16 @@ import net.minecraft.init.Items
 import net.minecraft.network.play.client.CPacketEntityAction
 import net.minecraft.network.play.client.CPacketPlayer
 import net.minecraft.network.play.server.SPacketPlayerPosLook
-import net.minecraft.util.math.MathHelper
 import kotlin.math.sqrt
+import kotlin.math.sin
+import kotlin.math.cos
 
 /**
  * Created by 086 on 11/04/2018.
  * Updated by Itistheend on 28/12/19.
  * Updated by dominikaaaa on 26/05/20
  * Updated by pNoName on 28/05/20
- * Updated by Xiaro on 20/06/20
+ * Updated by Xiaro on 21/06/20
  *
  * Some of Control mode was written by an anonymous donator who didn't wish to be named.
  */
@@ -145,7 +146,7 @@ class ElytraFlight : Module() {
         if (moveBackward) yawDeg -= 180.0f
 
         packetYaw = yawDeg
-        val yaw = Math.toRadians(yawDeg.toDouble()).toFloat()
+        val yaw = Math.toRadians(yawDeg.toDouble())
         val motionAmount = sqrt(mc.player.motionX * mc.player.motionX + mc.player.motionZ * mc.player.motionZ)
         hoverState = if (hoverState) mc.player.posY < hoverTarget + 0.1 else mc.player.posY < hoverTarget + 0.0
         val doHover: Boolean = hoverState && hoverControl.value
@@ -157,17 +158,17 @@ class ElytraFlight : Module() {
                 } else {
                     val calcMotionDiff = motionAmount * 0.008
                     mc.player.motionY += calcMotionDiff * 3.2
-                    mc.player.motionX -= (-MathHelper.sin(yaw)).toDouble() * calcMotionDiff / 1.0
-                    mc.player.motionZ -= MathHelper.cos(yaw).toDouble() * calcMotionDiff / 1.0
+                    mc.player.motionX -= (-sin(yaw)) * calcMotionDiff / 1.0
+                    mc.player.motionZ -= cos(yaw) * calcMotionDiff / 1.0
 
                     mc.player.motionX *= 0.99
                     mc.player.motionY *= 0.98
                     mc.player.motionZ *= 0.99
                 }
-            } else { /* runs when pressing wasd */
-                mc.player.motionX = (-MathHelper.sin(yaw)).toDouble() * speedControl.value
-                mc.player.motionY = (-fallSpeedControl.value).toDouble()
-                mc.player.motionZ = MathHelper.cos(yaw).toDouble() * speedControl.value
+            } else {/* runs when pressing wasd */
+                    mc.player.motionX = (-sin(yaw)) * speedControl.value
+                    mc.player.motionY = (-fallSpeedControl.value).toDouble()
+                    mc.player.motionZ = cos(yaw) * speedControl.value
             }
         } else { /* Stop moving if no inputs are pressed */
             mc.player.motionX = 0.0
@@ -224,12 +225,12 @@ class ElytraFlight : Module() {
 
             if (mc.gameSettings.keyBindForward.isKeyDown) {
                 val yaw = Math.toRadians(mc.player.rotationYaw.toDouble()).toFloat()
-                mc.player.motionX -= MathHelper.sin(yaw) * 0.05f.toDouble()
-                mc.player.motionZ += MathHelper.cos(yaw) * 0.05f.toDouble()
+                mc.player.motionX -= sin(yaw) * 0.05
+                mc.player.motionZ += cos(yaw) * 0.05
             } else if (mc.gameSettings.keyBindBack.isKeyDown) {
                 val yaw = Math.toRadians(mc.player.rotationYaw.toDouble()).toFloat()
-                mc.player.motionX += MathHelper.sin(yaw) * 0.05f.toDouble()
-                mc.player.motionZ -= MathHelper.cos(yaw) * 0.05f.toDouble()
+                mc.player.motionX += sin(yaw) * 0.05
+                mc.player.motionZ -= cos(yaw) * 0.05
             }
         } else if (mode.value == ElytraFlightMode.CREATIVE || mode.value == ElytraFlightMode.FLY) {
             mc.player.capabilities.flySpeed = .915f

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
@@ -23,7 +23,7 @@ import kotlin.math.cos
  * Updated by Itistheend on 28/12/19.
  * Updated by dominikaaaa on 26/05/20
  * Updated by pNoName on 28/05/20
- * Updated by Xiaro on 21/06/20
+ * Updated by Xiaro on 22/06/20
  *
  * Some of Control mode was written by an anonymous donator who didn't wish to be named.
  */

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
@@ -192,10 +192,15 @@ class ElytraFlight : Module() {
     })
 
     private fun lookBoost() {
-        if (mc.player.movementInput.moveForward > 0 && mc.player.movementInput.jump && spaceBarTrigger.value && mc.player.rotationPitch > -10) mc.player.rotationPitch = -10f
+        if (mc.player.movementInput.moveForward > 0 && mc.player.movementInput.jump && spaceBarTrigger.value && mc.player.rotationPitch > -10)
+            mc.player.rotationPitch = -25f
+
         val readyToBoost = mc.player.movementInput.moveForward > 0 && ((mc.player.movementInput.jump && spaceBarTrigger.value) || !spaceBarTrigger.value) && mc.player.rotationPitch <= -10
         val shouldAutoBoost = !autoBoost.value || ((mc.player.motionY >= (-fallSpeedControl.value) && sqrt(mc.player.motionX * mc.player.motionX + mc.player.motionZ * mc.player.motionZ) >= 0.8) || (mc.player.motionY >= 1))
-        if ((readyToBoost && shouldAutoBoost) != isBoosting) mc.player.rotationPitch -= 0.0001f /*Tried with sending rotation packet, doesn't work on 2B*/
+
+        if ((readyToBoost && shouldAutoBoost) != isBoosting)
+            mc.player.rotationPitch -= 0.0001f /* Tried with sending rotation packet, doesn't work on 2b2t.org */
+
         isBoosting = readyToBoost && shouldAutoBoost
     }
     /* End of Control Mode */

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
@@ -52,6 +52,7 @@ class ElytraFlight : Module() {
     private val upPitch = register(Settings.integerBuilder("Up Pitch").withRange(-90, 90).withValue(-10).withVisibility { spoofPitch.value && mode.value == ElytraFlightMode.CONTROL }.build())
     private val forwardPitch = register(Settings.integerBuilder("Forward Pitch").withRange(-90, 90).withValue(0).withVisibility { spoofPitch.value && mode.value == ElytraFlightMode.CONTROL }.build())
     private val lookBoost = register(Settings.booleanBuilder("Look Boost").withValue(true).withVisibility { mode.value == ElytraFlightMode.CONTROL }.build())
+    private val spaceBarTrigger = register(Settings.booleanBuilder("Space Bar Trigger").withValue(false).withVisibility { lookBoost.value && mode.value == ElytraFlightMode.CONTROL }.build())
     private val autoBoost = register(Settings.booleanBuilder("Auto Boost").withValue(true).withVisibility { lookBoost.value && mode.value == ElytraFlightMode.CONTROL }.build())
     private val hoverControl = register(Settings.booleanBuilder("Hover").withValue(false).withVisibility { mode.value == ElytraFlightMode.CONTROL }.build())
     private val easyTakeOffControl = register(Settings.booleanBuilder("Easy Takeoff C").withValue(true).withVisibility { mode.value == ElytraFlightMode.CONTROL }.build())
@@ -187,13 +188,14 @@ class ElytraFlight : Module() {
     })
 
     private fun lookBoost() {
+        val readyToBoost = mc.player.movementInput.moveForward > 0 && ((mc.player.movementInput.jump && spaceBarTrigger.value) || !spaceBarTrigger.value) && mc.player.rotationPitch <= -10
         val shouldAutoBoost = if (autoBoost.value) {
-            !(mc.player.motionX.toInt() == 0 && mc.player.motionZ.toInt() == 0)
+            (mc.player.motionY >= (-fallSpeedControl.value) && sqrt(mc.player.motionX * mc.player.motionX + mc.player.motionZ * mc.player.motionZ) >= 0.8) || (mc.player.motionY >= 1) /*Make auto boost works great at all pitch*/
         } else {
             true
         }
-
-        isBoosting = (mc.player.rotationPitch < -10 && shouldAutoBoost) && lookBoost.value
+        if ((readyToBoost && shouldAutoBoost) != isBoosting) mc.player.rotationPitch -= 0.0001f /*Tried with sending rotation packet, doesn't work on 2B*/
+        isBoosting = readyToBoost && shouldAutoBoost
     }
     /* End of Control Mode */
 
@@ -315,6 +317,7 @@ class ElytraFlight : Module() {
             upPitch.value = -10
             forwardPitch.value = 0
             lookBoost.value = true
+            spaceBarTrigger.value = false
             autoBoost.value = true
             hoverControl.value = false
             easyTakeOffControl.value = true

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/ElytraFlight.kt
@@ -185,6 +185,16 @@ class ElytraFlight : Module() {
         }
         event.cancel()
     })
+
+    private fun lookBoost() {
+        val shouldAutoBoost = if (autoBoost.value) {
+            !(mc.player.motionX.toInt() == 0 && mc.player.motionZ.toInt() == 0)
+        } else {
+            true
+        }
+
+        isBoosting = (mc.player.rotationPitch < -10 && shouldAutoBoost) && lookBoost.value
+    }
     /* End of Control Mode */
 
     override fun onUpdate() {
@@ -193,13 +203,11 @@ class ElytraFlight : Module() {
         if (!elytraIsEquipped || mc.player == null || mc.player.isSpectator) return
 
         if (mode.value == ElytraFlightMode.CONTROL) {
-            val shouldAutoBoost = if (autoBoost.value) {
-                !(mc.player.motionX.toInt() == 0 && mc.player.motionZ.toInt() == 0)
+            if (mc.player.isElytraFlying && lookBoost.value) {
+                lookBoost()
             } else {
-                true
+                isBoosting = false
             }
-
-            isBoosting = (mc.player.rotationPitch < -10 && shouldAutoBoost) && lookBoost.value
             return
         }
 


### PR DESCRIPTION
**Describe the pull**
1, Replace MathHelper functions with Kotlin functions.
2, Move look boost codes into a separated function.
3, Look boost will not be triggered if not moving forward.
4, Added space bar trigger option for look boost.
5. Improved auto boost.
6. Update server-side pitch in the beginning and the end of boosting.

**Describe how this pull is helpful**
1, Avoids exceeding the speed limit on some servers because of miscalculation, issue #942 
2, Easier to maintain the code.
3, Allows you look around freely without going into boosting status when not moving.
4, Allows you look up freely while flying, issue #938 
5, Make it works properly at all pitch and all direction.
6, Allows you to use auto boost without needing looking down manually, issue #938  

**Additional context**
On 2b2t, Auto boost doesn't work if your pitch is above 52° because of an old patch.
Something when wrong in the old pull request so I closed and make a new one. Sorry for the spam.