### PR TITLE
ChatTranslate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     compile group: "org.jetbrains", name: "annotations", version: annotations_version
     compile group: "org.jetbrains.kotlinx", name: "kotlinx-coroutines-core", version: coroutines_version
     compile group: "org.jetbrains.kotlinx", name: "kotlinx-coroutines-jdk8", version: coroutines_version
+    compile 'com.google.cloud:google-cloud-translate:1.95.0'
 }
 
 processResources {
@@ -148,6 +149,7 @@ shadowJar {
         include(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutines_version}"))
         include(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${coroutines_version}"))
         include(dependency('net.shadowfacts:Forgelin'))
+        include(dependency('com.google.cloud:google-cloud-translate:1.95.0'))
     }
     exclude 'dummyThing' // can someone explain why this is here
     classifier = 'release'

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatTranslate.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatTranslate.java
@@ -1,0 +1,35 @@
+package me.zeroeightsix.kami.module.modules.chat;
+
+import me.zeroeightsix.kami.module.Module;
+import com.google.gson.*;
+import com.google.cloud.translate.*;
+import me.zeroeightsix.kami.util.MessageDetectionHelper;
+import static me.zeroeightsix.kami.util.MessageSendHelper.sendChatMessage;
+
+@Module.Info(
+        name = "ChatTranslate",
+        description = "Translates Chat",
+        category = Module.Category.CHAT
+)
+public class ChatTranslate extends Module{
+    public ChatTranslate(){}
+    Translate translate = TranslateOptions.getDefaultInstance().getService();
+    String msg;
+    Translation translation;
+
+    @Override
+    public void onEnable(){
+        if(MessageDetectionHelper.isDirect(true, msg)){
+            translation = translate.translate(msg);
+            sendChatMessage(translation.toString());
+        }
+    }
+
+    @Override
+    public void onUpdate(){
+        if(MessageDetectionHelper.isDirect(true, msg)){
+            translation = translate.translate(msg);
+            sendChatMessage(translation.toString());
+        }
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatTranslate.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatTranslate.java
@@ -1,35 +1,63 @@
 package me.zeroeightsix.kami.module.modules.chat;
 
+import me.zero.alpine.listener.EventHandler;
+import me.zero.alpine.listener.Listener;
 import me.zeroeightsix.kami.module.Module;
 import com.google.gson.*;
 import com.google.cloud.translate.*;
-import me.zeroeightsix.kami.util.MessageDetectionHelper;
+import me.zeroeightsix.kami.setting.Setting;
+import me.zeroeightsix.kami.setting.Settings;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+
 import static me.zeroeightsix.kami.util.MessageSendHelper.sendChatMessage;
 
+@SuppressWarnings("FieldMayBeFinal")
 @Module.Info(
         name = "ChatTranslate",
         description = "Translates Chat",
         category = Module.Category.CHAT
 )
 public class ChatTranslate extends Module{
-    public ChatTranslate(){}
-    Translate translate = TranslateOptions.getDefaultInstance().getService();
-    String msg;
-    Translation translation;
+    private Setting<Boolean> fullChat = register(Settings.b("Translate Everything", false));
+    private Setting<Boolean> dmsOnly = register(Settings.b("Only Translate /msg", true));
+    private Setting<Languages> fromLanguage = register(Settings.e("From Language", Languages.TRADITIONAL_CHINESE));
+    private Setting<Languages> toLanguage = register(Settings.e("To Language", Languages.ENGLISH));
 
-    @Override
-    public void onEnable(){
-        if(MessageDetectionHelper.isDirect(true, msg)){
-            translation = translate.translate(msg);
-            sendChatMessage(translation.toString());
+
+    Translate translate = TranslateOptions.getDefaultInstance().getService();
+    Translation translation;
+    String msg;
+
+    enum Languages {
+        ENGLISH("en"),
+        SPANISH("es"),
+        SIMPLIFIED_CHINESE("zh-CN"),
+        TRADITIONAL_CHINESE("zh-TW"),
+        RUSSIAN("ru"),
+        FRENCH("fr"),
+        GERMAN("de");
+
+        public final String value;
+
+        Languages(String value) {
+            this.value = value;
         }
     }
 
+    @EventHandler
+    public Listener<ClientChatReceivedEvent> listener = new Listener<>(event -> {
+        msg = event.getMessage().getUnformattedText();
+        onUpdate();
+    });
+
     @Override
     public void onUpdate(){
-        if(MessageDetectionHelper.isDirect(true, msg)){
-            translation = translate.translate(msg);
-            sendChatMessage(translation.toString());
-        }
+        translation = translate.translate(
+                msg,
+                Translate.TranslateOption.sourceLanguage(String.valueOf(Languages.SIMPLIFIED_CHINESE)),
+                Translate.TranslateOption.targetLanguage(String.valueOf(Languages.ENGLISH)),
+                Translate.TranslateOption.model("base")
+        );
+        sendChatMessage(translation.toString());
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatTranslate.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/chat/ChatTranslate.java
@@ -11,6 +11,9 @@ import net.minecraftforge.client.event.ClientChatReceivedEvent;
 
 import static me.zeroeightsix.kami.util.MessageSendHelper.sendChatMessage;
 
+/**
+ * Created by sourTaste000 on 7/3/2020
+ */
 @SuppressWarnings("FieldMayBeFinal")
 @Module.Info(
         name = "ChatTranslate",
@@ -18,8 +21,6 @@ import static me.zeroeightsix.kami.util.MessageSendHelper.sendChatMessage;
         category = Module.Category.CHAT
 )
 public class ChatTranslate extends Module{
-    private Setting<Boolean> fullChat = register(Settings.b("Translate Everything", false));
-    private Setting<Boolean> dmsOnly = register(Settings.b("Only Translate /msg", true));
     private Setting<Languages> fromLanguage = register(Settings.e("From Language", Languages.TRADITIONAL_CHINESE));
     private Setting<Languages> toLanguage = register(Settings.e("To Language", Languages.ENGLISH));
 
@@ -44,20 +45,20 @@ public class ChatTranslate extends Module{
         }
     }
 
-    @EventHandler
-    public Listener<ClientChatReceivedEvent> listener = new Listener<>(event -> {
-        msg = event.getMessage().getUnformattedText();
-        onUpdate();
-    });
+        @EventHandler
+        public Listener<ClientChatReceivedEvent> listener = new Listener<>(event -> {
+            msg = event.getMessage().getUnformattedText();
+            onUpdate();
+        });
 
     @Override
     public void onUpdate(){
         translation = translate.translate(
                 msg,
-                Translate.TranslateOption.sourceLanguage(String.valueOf(Languages.SIMPLIFIED_CHINESE)),
-                Translate.TranslateOption.targetLanguage(String.valueOf(Languages.ENGLISH)),
+                Translate.TranslateOption.sourceLanguage(String.valueOf(fromLanguage)),
+                Translate.TranslateOption.targetLanguage(String.valueOf(toLanguage)),
                 Translate.TranslateOption.model("base")
         );
-        sendChatMessage(translation.toString());
+        sendChatMessage("Translated text (From " + fromLanguage + " to " + toLanguage + ") " + translation.toString());
     }
 }


### PR DESCRIPTION
**Describe the pull**
Added ChatTranslate Module (#999 )

**Describe how this pull is helpful**
Should close #999 when there is no error 

**Additional context**
Error:
```
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: java.lang.NoClassDefFoundError: com/google/cloud/translate/TranslateOptions
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at me.zeroeightsix.kami.module.modules.chat.ChatTranslate.<init>(ChatTranslate.java:27)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.lang.reflect.Constructor.newInstance(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at me.zeroeightsix.kami.module.ModuleManager.lambda$register$0(ModuleManager.java:38)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.SortedOps$SizedRefSortingSink.end(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.AbstractPipeline.copyInto(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.AbstractPipeline.evaluate(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.util.stream.ReferencePipeline.forEach(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at me.zeroeightsix.kami.module.ModuleManager.register(ModuleManager.java:36)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at me.zeroeightsix.kami.KamiMod.init(KamiMod.java:140)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.lang.reflect.Method.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:637)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.GeneratedMethodAccessor10.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.lang.reflect.Method.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:219)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:197)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.lang.reflect.Method.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at com.google.common.eventbus.EventBus.post(EventBus.java:217)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:136)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraftforge.fml.common.Loader.initializeMods(Loader.java:749)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraftforge.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:336)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:535)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:378)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraft.client.main.Main.main(SourceFile:123)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.lang.reflect.Method.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at java.lang.reflect.Method.invoke(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
[10:28:34] [Client thread/INFO] [STDERR]: [me.zeroeightsix.kami.module.ModuleManager:lambda$register$0:41]: 	at org.multimc.EntryPoint.main(EntryPoint.java:34)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: Caused by: java.lang.ClassNotFoundException: com.google.cloud.translate.TranslateOptions
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.lang.ClassLoader.loadClass(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.lang.ClassLoader.loadClass(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	... 64 more
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: Caused by: java.lang.NoClassDefFoundError: com/google/cloud/ServiceOptions
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.lang.ClassLoader.defineClass1(Native Method)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.lang.ClassLoader.defineClass(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.security.SecureClassLoader.defineClass(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:182)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	... 66 more
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: Caused by: java.lang.ClassNotFoundException: com.google.cloud.ServiceOptions
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:101)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.lang.ClassLoader.loadClass(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	at java.lang.ClassLoader.loadClass(Unknown Source)
[10:28:34] [Client thread/INFO] [STDERR]: [java.lang.Throwable:printStackTrace:-1]: 	... 70 more
```
