### PR TITLE
Added a delay setting to AutoRemount.

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/AutoRemount.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/AutoRemount.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
  * Created by dominikaaaa on 05/04/20
  * updated by ionar2 on 04/05/20
  * Updated by dominikaaaa on 05/06/20
+ * Updated by Superfly_Johnson on 07/21/20
  */
 @Module.Info(
         name = "AutoRemount",
@@ -30,11 +31,19 @@ public class AutoRemount extends Module {
     private Setting<Boolean> pig = register(Settings.b("Pig", true));
     private Setting<Boolean> llama = register(Settings.b("Llama", true));
     private Setting<Float> range = register(Settings.floatBuilder("Range").withMinimum(1.0f).withValue(2.0f).withMaximum(10.0f).build());
+    private Setting<Integer> delay = register(Settings.integerBuilder("Delay").withMinimum(-1).withValue(5).withMaximum(100).build());
+
+    private int timer = delay.getValue();
 
     public void onUpdate() {
-        // we don't need to do anything if we're already riding.
         if (mc.player.isRiding())
             return;
+
+        // Bad. There is no way to check if a setting has been changed, this workaround works
+        // but results in the value of timer being set to -1 every cycle. A onSettingChanged event
+        // would fix this.
+        if (timer>0){timer--;return;}
+        else {timer=delay.getValue();}
 
         mc.world.loadedEntityList.stream()
                 .filter(this::isValidEntity)


### PR DESCRIPTION
**Describe the pull**
Added a delay/timer to the AutoRemount module.
**Describe how this pull is helpful**
A delay option on the AutoRemount module allows the player to remount an entity just as often while reducing the risk to get kicked by server.

**Additional context**
Tested on Constantiam.net as part of a bug hunting campaign.