### PR TITLE
Add ShowHidden option to ActiveModules

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -32,20 +32,16 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_TEXTURE_2D);
 
-        FontRenderer renderer = Wrapper.getFontRenderer();
-        List<Module> Visualmods = MODULE_MANAGER.getModules().stream()
-                .filter(Module::isEnabled)
-                .filter(Module::isOnArray)
-                .sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
-                .collect(Collectors.toList());
-        
-        List<Module> Enabledmods = MODULE_MANAGER.getModules().stream()
-	    		.filter(Module::isEnabled)
-                .sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
-	            .collect(Collectors.toList());
-	        
-        final int[] y = {2};
         activeMods = MODULE_MANAGER.getModuleT(ActiveModules.class);
+        
+        FontRenderer renderer = Wrapper.getFontRenderer();
+	    List<Module> mods = MODULE_MANAGER.getModules().stream()
+		    	.filter(Module::isEnabled)
+	    		.filter(Module -> (activeMods.hidden.getValue() ? 1 == 1 : Module.isOnArray()))
+		    	.sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
+	            	.collect(Collectors.toList());
+
+        final int[] y = {2};
 
         if (activeMods.potion.getValue() && component.getParent().getY() < 26 && Wrapper.getPlayer().getActivePotionEffects().size() > 0 && component.getParent().getOpacity() == 0)
             y[0] = Math.max(component.getParent().getY(), 26 - component.getParent().getY());
@@ -66,8 +62,8 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
                 break;
         }
 
-        for (int i = 0 ; i < (activeMods.hidden.getValue() ? Enabledmods.size(): Visualmods.size()) ; i++) {
-            Module module = activeMods.hidden.getValue() ? Enabledmods.get(i): Visualmods.get(i);
+        for (int i = 0 ; i < mods.size() ; i++) {
+            Module module = mods.get(i);
             int rgb;
 
             switch (activeMods.mode.getValue()) {

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -33,12 +33,17 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
         GL11.glEnable(GL11.GL_TEXTURE_2D);
 
         FontRenderer renderer = Wrapper.getFontRenderer();
-        List<Module> mods = MODULE_MANAGER.getModules().stream()
+        List<Module> Visualmods = MODULE_MANAGER.getModules().stream()
                 .filter(Module::isEnabled)
                 .filter(Module::isOnArray)
                 .sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
                 .collect(Collectors.toList());
-
+        
+        List<Module> Enabledmods = MODULE_MANAGER.getModules().stream()
+	    		.filter(Module::isEnabled)
+                .sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
+	            .collect(Collectors.toList());
+	        
         final int[] y = {2};
         activeMods = MODULE_MANAGER.getModuleT(ActiveModules.class);
 
@@ -61,8 +66,8 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
                 break;
         }
 
-        for (int i = 0 ; i < mods.size() ; i++) {
-            Module module = mods.get(i);
+        for (int i = 0 ; i < (activeMods.hidden.getValue() ? Enabledmods.size(): Visualmods.size()) ; i++) {
+            Module module = activeMods.hidden.getValue() ? Enabledmods.get(i): Visualmods.get(i);
             int rgb;
 
             switch (activeMods.mode.getValue()) {

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -35,11 +35,10 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
         activeMods = MODULE_MANAGER.getModuleT(ActiveModules.class);
         
         FontRenderer renderer = Wrapper.getFontRenderer();
-	    List<Module> mods = MODULE_MANAGER.getModules().stream()
-		    	.filter(Module::isEnabled)
-	    		.filter(Module -> (activeMods.hidden.getValue() ? 1 == 1 : Module.isOnArray()))
-		    	.sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
-	            	.collect(Collectors.toList());
+	List<Module> mods = MODULE_MANAGER.getModules().stream()
+		.filter(Module::isEnabled).filter(Module -> (activeMods.hidden.getValue() ? true : Module.isOnArray()))
+		.sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
+		.collect(Collectors.toList());
 
         final int[] y = {2};
 

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -37,7 +37,8 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
 
         FontRenderer renderer = Wrapper.getFontRenderer();
         List<Module> mods = MODULE_MANAGER.getModules().stream()
-                .filter(Module::isEnabled).filter(Module -> (activeMods.hidden.getValue() || Module.isOnArray()))
+                .filter(Module::isEnabled)
+                .filter(Module -> (activeMods.hidden.getValue() || Module.isOnArray()))
                 .sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
                 .collect(Collectors.toList());
 

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -34,8 +34,8 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
         GL11.glEnable(GL11.GL_TEXTURE_2D);
 
         activeMods = MODULE_MANAGER.getModuleT(ActiveModules.class);
-
         FontRenderer renderer = Wrapper.getFontRenderer();
+
         List<Module> mods = MODULE_MANAGER.getModules().stream()
                 .filter(Module::isEnabled)
                 .filter(Module -> (activeMods.hidden.getValue() || Module.isOnArray()))

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -63,7 +63,7 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
                 break;
         }
 
-        for (int i = 0; i < mods.size(); i++) {
+        for (int i = 0 ; i < mods.size() ; i++) {
             Module module = mods.get(i);
             int rgb;
 

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiActiveModulesUI.java
@@ -26,6 +26,7 @@ import static org.lwjgl.opengl.GL11.glDisable;
  */
 public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kami.gui.kami.component.ActiveModules> {
     ActiveModules activeMods;
+
     @Override
     public void renderComponent(me.zeroeightsix.kami.gui.kami.component.ActiveModules component, FontRenderer f) {
         GL11.glDisable(GL11.GL_CULL_FACE);
@@ -33,12 +34,12 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
         GL11.glEnable(GL11.GL_TEXTURE_2D);
 
         activeMods = MODULE_MANAGER.getModuleT(ActiveModules.class);
-        
+
         FontRenderer renderer = Wrapper.getFontRenderer();
-	List<Module> mods = MODULE_MANAGER.getModules().stream()
-		.filter(Module::isEnabled).filter(Module -> (activeMods.hidden.getValue() ? true : Module.isOnArray()))
-		.sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
-		.collect(Collectors.toList());
+        List<Module> mods = MODULE_MANAGER.getModules().stream()
+                .filter(Module::isEnabled).filter(Module -> (activeMods.hidden.getValue() || Module.isOnArray()))
+                .sorted(Comparator.comparing(module -> renderer.getStringWidth(module.getName() + (module.getHudInfo() == null ? "" : module.getHudInfo() + " ")) * (component.sort_up ? -1 : 1)))
+                .collect(Collectors.toList());
 
         final int[] y = {2};
 
@@ -61,7 +62,7 @@ public class KamiActiveModulesUI extends AbstractComponentUI<me.zeroeightsix.kam
                 break;
         }
 
-        for (int i = 0 ; i < mods.size() ; i++) {
+        for (int i = 0; i < mods.size(); i++) {
             Module module = mods.get(i);
             int rgb;
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/client/ActiveModules.java
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/client/ActiveModules.java
@@ -30,6 +30,7 @@ import static me.zeroeightsix.kami.util.MessageSendHelper.sendDisableMessage;
 public class ActiveModules extends Module {
     private Setting<Boolean> forgeHax = register(Settings.b("ForgeHax", false));
     public Setting<Boolean> potion = register(Settings.b("PotionsMove", false));
+    public Setting<Boolean> hidden = register(Settings.b("ShowHidden", false));
     public Setting<Mode> mode = register(Settings.e("Mode", Mode.RAINBOW));
     private Setting<Integer> rainbowSpeed = register(Settings.integerBuilder().withName("SpeedR").withValue(30).withMinimum(0).withMaximum(100).withVisibility(v -> mode.getValue().equals(Mode.RAINBOW)).build());
     public Setting<Integer> saturationR = register(Settings.integerBuilder().withName("SaturationR").withValue(117).withMinimum(0).withMaximum(255).withVisibility(v -> mode.getValue().equals(Mode.RAINBOW)).build());


### PR DESCRIPTION
**Describe the pull**
This pull adds an option, ShowHidden, to the ActiveModules module that displays all enabled modules in the ActiveModules list.

**Describe how this pull is helpful**
Like most people, I try to keep my overlay clean by removing most of the modules I have enabled all the time from the ActiveModules list. But sometimes I can't remember if I have something enabled or not, and I have to search through the clickGUI to find out. The option ShowHidden displays all active modules to the ActiveModule list even if they have been toggled to not show on array. This makes it easy to see all of the active modules.

**Additional context**
I'm very bad at naming things so if anything doesn't seem to have a good name I don't care if it's changed
