### PR TITLE
Initial attempt on in game waypoint rendering

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/command/commands/WaypointCommand.kt
+++ b/src/main/java/me/zeroeightsix/kami/command/commands/WaypointCommand.kt
@@ -37,12 +37,12 @@ class WaypointCommand : Command("waypoint", ChunkBuilder().append("command", tru
                             }
                             val split = args[2]!!.split(",").toTypedArray()
                             val coordinate = Coordinate(split[0].toInt(), split[1].toInt(), split[2].toInt())
-                            confirm(args[1]!!, createWaypoint(coordinate, args[1]!!))
+                            confirm(args[1]!!, createWaypoint(coordinate, args[1]!!, 0))
                         } else {
-                            confirm(args[1]!!, writePlayerCoords(args[1]!!))
+                            confirm(args[1]!!, writePlayerCoords(args[1]!!, 0))
                         }
                     } else {
-                        confirm("Unnamed", writePlayerCoords("Unnamed"))
+                        confirm("Unnamed", writePlayerCoords("Unnamed", 0))
                     }
                 }
                 "remove" -> delete(args)

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/VisualRange.kt
@@ -51,7 +51,7 @@ class VisualRange : Module() {
                         sendNotification(ChatFormatting.RED.toString() + playerName + ChatFormatting.RESET.toString() + " joined!")
                     }
                     if (logToFile.value) {
-                        Waypoint.writePlayerCoords("$playerName spotted!")
+                        Waypoint.writePlayerCoords("$playerName spotted!", 4)
                     }
                     if (uwuAura.value) MessageSendHelper.sendServerMessage("/w $playerName hi uwu")
                     return

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoRespawn.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoRespawn.kt
@@ -32,7 +32,7 @@ class AutoRespawn : Module() {
         }
 
         if (deathCoords.value && mc.player.health <= 0) {
-            Waypoint.writePlayerCoords("Death - " + InfoCalculator.getServerType(mc))
+            Waypoint.writePlayerCoords("Death - " + InfoCalculator.getServerType(mc), 5)
             MessageSendHelper.sendChatMessage(String.format("You died at x %d y %d z %d",
                     mc.player.posX.toInt(),
                     mc.player.posY.toInt(),

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/CoordsLog.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/CoordsLog.kt
@@ -63,7 +63,7 @@ class CoordsLog : Module() {
     }
 
     private fun logCoordinates(name: String): Coordinate {
-        return Waypoint.writePlayerCoords(name)
+        return Waypoint.writePlayerCoords(name, 4)
     }
 
     public override fun onDisable() {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/LogoutLogger.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/LogoutLogger.kt
@@ -75,7 +75,7 @@ class LogoutLogger : Module() {
 
     private fun logCoordinates(coordinate: Coordinate, name: String): Coordinate {
         return if (saveToFile.value) {
-            Waypoint.createWaypoint(coordinate, name)
+            Waypoint.createWaypoint(coordinate, name, 1)
         } else {
             coordinate
         }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/StashFinder.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/StashFinder.kt
@@ -102,7 +102,7 @@ class StashFinder : Module() {
             chunkStats.hot = false
 
             // mfw int array instead of Vec3i
-            Waypoint.createWaypoint(chunkStats.getBlockPos(), chunkStats.toString())
+            Waypoint.createWaypoint(chunkStats.getBlockPos(), chunkStats.toString(), 2)
 
             if (playSound.value) {
                 mc.getSoundHandler().playSound(PositionedSoundRecord.getRecord(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP, 1.0f, 1.0f))

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/TeleportLogger.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/TeleportLogger.kt
@@ -55,7 +55,7 @@ class TeleportLogger : Module() {
 
     private fun logCoordinates(coordinate: Coordinate, name: String): Coordinate {
         return if (saveToFile.value) {
-            Waypoint.createWaypoint(coordinate, name)
+            Waypoint.createWaypoint(coordinate, name, 3)
         } else {
             coordinate
         }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Waypoints.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Waypoints.kt
@@ -1,0 +1,138 @@
+package me.zeroeightsix.kami.module.modules.render
+
+import me.zeroeightsix.kami.event.events.RenderEvent
+import me.zeroeightsix.kami.module.FileInstanceManager
+import me.zeroeightsix.kami.module.Module
+import me.zeroeightsix.kami.setting.Settings
+import me.zeroeightsix.kami.util.ColourConverter
+import me.zeroeightsix.kami.util.KamiTessellator
+import me.zeroeightsix.kami.util.WaypointInfo
+import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.client.renderer.RenderHelper
+import net.minecraft.client.renderer.Tessellator
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats
+import org.lwjgl.opengl.GL11
+import java.util.function.Consumer
+
+/**
+ * @author Guacamole
+ * Created by Guacamole on 31/07/20
+ */
+@Module.Info(
+        name = "Waypoints",
+        description = "Allows rendering of waypoints set using waypoint command",
+        category = Module.Category.RENDER
+)
+class Waypoints : Module() {
+    private val page = register(Settings.e<Page>("Page", Page.GENERIC_SETTINGS))
+    /* Generic Settings */
+    private val radius = register(Settings.doubleBuilder("Scale").withMinimum(1.0).withMaximum(16.0).withValue(6.0).withVisibility { page.value == Page.GENERIC_SETTINGS }.build())
+    private val tracers = register(Settings.booleanBuilder("Tracers").withValue(false).withVisibility { page.value == Page.GENERIC_SETTINGS }.build())
+    private val customTracerColor = register(Settings.booleanBuilder("CustomTracerColor").withValue(true).withVisibility { page.value == Page.GENERIC_SETTINGS }.build())
+    private val tr = register(Settings.integerBuilder("Red").withMinimum(0).withValue(155).withMaximum(255).withVisibility { customTracerColor.value && page.value == Page.GENERIC_SETTINGS }.build())
+    private val tg = register(Settings.integerBuilder("Green").withMinimum(0).withValue(144).withMaximum(255).withVisibility { customTracerColor.value && page.value == Page.GENERIC_SETTINGS }.build())
+    private val tb = register(Settings.integerBuilder("Blue").withMinimum(0).withValue(255).withMaximum(255).withVisibility { customTracerColor.value && page.value == Page.GENERIC_SETTINGS }.build())
+    private val customFontColor = register(Settings.booleanBuilder("CustomFontColor").withValue(false).withVisibility { page.value == Page.GENERIC_SETTINGS }.build())
+    private val fr = register(Settings.integerBuilder("Red").withMinimum(0).withValue(155).withMaximum(255).withVisibility { customFontColor.value && page.value == Page.GENERIC_SETTINGS }.build())
+    private val fg = register(Settings.integerBuilder("Green").withMinimum(0).withValue(144).withMaximum(255).withVisibility { customFontColor.value && page.value == Page.GENERIC_SETTINGS }.build())
+    private val fb = register(Settings.integerBuilder("Blue").withMinimum(0).withValue(255).withMaximum(255).withVisibility { customFontColor.value && page.value == Page.GENERIC_SETTINGS }.build())
+    private val test = register(Settings.doubleBuilder("test").withMinimum(-2.0).withMaximum(2.0).withValue(0.0).build())
+
+    /* Waypoint Types */
+    private val t0 = register(Settings.booleanBuilder("Normal").withValue(true).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())
+    private val t1 = register(Settings.booleanBuilder("LogoutSpot").withValue(false).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())
+    private val t2 = register(Settings.booleanBuilder("Stash").withValue(false).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())
+    private val t3 = register(Settings.booleanBuilder("TeleportSpot").withValue(false).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())
+    private val t5 = register(Settings.booleanBuilder("Death").withValue(false).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())
+    private val t4 = register(Settings.booleanBuilder("Other").withValue(false).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())
+
+    private enum class Page {
+        GENERIC_SETTINGS, WAYPOINT_TYPES
+    }
+
+    override fun onWorldRender(event: RenderEvent) {
+        val waypoints = FileInstanceManager.waypoints
+
+        val viewerYaw = mc.getRenderManager().playerViewY
+        val viewerPitch = mc.getRenderManager().playerViewX
+        val isThirdPersonFrontal = try { mc.getRenderManager().options.thirdPersonView == 2 } catch (ignored: NullPointerException) { false }
+        val maxDistance = (mc.getRenderManager().options?.renderDistanceChunks ?: 10) * 16
+        var zoomer2 = maxDistance / radius.value
+
+        waypoints.forEach(Consumer { waypoint: WaypointInfo ->
+            if (waypoint.wpType == 0 && !t0.value) return@Consumer
+            else if (waypoint.wpType == 1 && !t1.value) return@Consumer
+            else if (waypoint.wpType == 2 && !t2.value) return@Consumer
+            else if (waypoint.wpType == 3 && !t3.value) return@Consumer
+            else if (waypoint.wpType == 4 && !t4.value) return@Consumer
+            else if (waypoint.wpType == 5 && !t5.value) return@Consumer
+
+            GlStateManager.pushMatrix()
+            GlStateManager.disableLighting()
+
+            val str = "${waypoint.name}"
+            val x = waypoint.pos.getX().toDouble()
+            val y = waypoint.pos.getY().toDouble()
+            val z = waypoint.pos.getZ().toDouble()
+            var offX = x - mc.getRenderManager().renderPosX
+            var offY = y - mc.getRenderManager().renderPosY
+            var offZ = z - mc.getRenderManager().renderPosZ
+            val dist = mc.player.getDistance(x, y, z)
+            val zoomer3 = maxDistance / dist
+            if (dist > radius.value) {
+                offX *= zoomer3
+                offY *= zoomer3
+                offY += 1.6f * (1.0f - zoomer3)
+                offZ *= zoomer3
+            } else {
+                offX *= zoomer2
+                offY *= zoomer2
+                offY += 1.6f * (1.0f - zoomer2)
+                offZ *= zoomer2
+            }
+            GlStateManager.translate(offX, offY, offZ)
+            GlStateManager.rotate(-viewerYaw, 0.0f, 1.0f, 0.0f)
+            GlStateManager.rotate((if (isThirdPersonFrontal) -1 else 1).toFloat() * viewerPitch, 1.0f, 0.0f, 0.0f)
+            GlStateManager.scale(-0.025f, -0.025f, 0.025f)
+            GlStateManager.scale(zoomer2, zoomer2, zoomer2)
+            val fontRendererIn = mc.fontRenderer
+            val i: Int = fontRendererIn.getStringWidth(str) / 2
+            GlStateManager.enableBlend()
+            GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO)
+            GlStateManager.disableTexture2D()
+
+            val tessellator = Tessellator.getInstance()
+            val bufferbuilder = tessellator.buffer
+
+            GlStateManager.disableDepth()
+            GL11.glTranslatef(0f, -20f, 0f)
+            bufferbuilder.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR)
+            bufferbuilder.pos(-i - 1.toDouble(), 8.0, 0.0).color(0.0f, 0.0f, 0.0f, 0.5f).endVertex()
+            bufferbuilder.pos(-i - 1.toDouble(), 19.0, 0.0).color(0.0f, 0.0f, 0.0f, 0.5f).endVertex()
+            bufferbuilder.pos(i + 1.toDouble(), 19.0, 0.0).color(0.0f, 0.0f, 0.0f, 0.5f).endVertex()
+            bufferbuilder.pos(i + 1.toDouble(), 8.0, 0.0).color(0.0f, 0.0f, 0.0f, 0.5f).endVertex()
+            tessellator.draw()
+
+            bufferbuilder.begin(GL11.GL_LINE_LOOP, DefaultVertexFormats.POSITION_COLOR)
+            bufferbuilder.pos(-i - 1.toDouble(), 8.0, 0.0).color(.1f, .1f, .1f, .1f).endVertex()
+            bufferbuilder.pos(-i - 1.toDouble(), 19.0, 0.0).color(.1f, .1f, .1f, .1f).endVertex()
+            bufferbuilder.pos(i + 1.toDouble(), 19.0, 0.0).color(.1f, .1f, .1f, .1f).endVertex()
+            bufferbuilder.pos(i + 1.toDouble(), 8.0, 0.0).color(.1f, .1f, .1f, .1f).endVertex()
+            tessellator.draw()
+
+            GlStateManager.enableTexture2D()
+            GlStateManager.glNormal3f(0.0f, 1.0f, 0.0f)
+            fontRendererIn.drawString(str, -i, 10, if (customFontColor.value) ColourConverter.rgbToInt(fr.value, fg.value, fb.value, 255) else ColourConverter.rgbToInt(155, 144, 255, 255))
+            if (tracers.value) KamiTessellator.drawLineToPos(x, y, z, if (customTracerColor.value) ColourConverter.rgbToInt(tr.value, tg.value, tb.value, 255) else ColourConverter.rgbToInt(155, 144, 255, 255), 255F)
+            GlStateManager.glNormal3f(0.0f, 0.0f, 0.0f)
+            GL11.glTranslatef(0f, 20f, 0f)
+
+            GlStateManager.scale(-40f, -40f, 40f)
+            GlStateManager.enableDepth()
+            GlStateManager.popMatrix()
+
+            RenderHelper.disableStandardItemLighting()
+            GlStateManager.enableLighting()
+        })
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Waypoints.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Waypoints.kt
@@ -36,7 +36,6 @@ class Waypoints : Module() {
     private val fr = register(Settings.integerBuilder("Red").withMinimum(0).withValue(155).withMaximum(255).withVisibility { customFontColor.value && page.value == Page.GENERIC_SETTINGS }.build())
     private val fg = register(Settings.integerBuilder("Green").withMinimum(0).withValue(144).withMaximum(255).withVisibility { customFontColor.value && page.value == Page.GENERIC_SETTINGS }.build())
     private val fb = register(Settings.integerBuilder("Blue").withMinimum(0).withValue(255).withMaximum(255).withVisibility { customFontColor.value && page.value == Page.GENERIC_SETTINGS }.build())
-    private val test = register(Settings.doubleBuilder("test").withMinimum(-2.0).withMaximum(2.0).withValue(0.0).build())
 
     /* Waypoint Types */
     private val t0 = register(Settings.booleanBuilder("Normal").withValue(true).withVisibility { page.value == Page.WAYPOINT_TYPES }.build())

--- a/src/main/java/me/zeroeightsix/kami/util/Waypoint.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/Waypoint.kt
@@ -63,14 +63,24 @@ object Waypoint {
         return Coordinate(mc.player.posX.toInt(), mc.player.posY.toInt(), mc.player.posZ.toInt())
     }
 
-    fun writePlayerCoords(locationName: String): Coordinate {
+    fun writePlayerCoords(locationName: String, type: Int): Coordinate {
         val coord = getCurrentCoord()
-        createWaypoint(coord, locationName)
+        createWaypoint(coord, locationName, type)
         return coord
     }
 
-    fun createWaypoint(xyz: Coordinate, locationName: String): Coordinate {
-        FileInstanceManager.waypoints.add(dateFormatter(xyz, locationName))
+    /**
+     * Waypoint types:
+     * 0 - Waypoint
+     * 1 - LogSpot
+     * 2 - Stash
+     * 3 - TeleportSpot
+     * 4 - Other
+     * 5 - Death
+     */
+
+    fun createWaypoint(xyz: Coordinate, locationName: String, type: Int): Coordinate {
+        FileInstanceManager.waypoints.add(dateFormatter(xyz, locationName, type))
 
         KamiMod.EVENT_BUS.post(WaypointUpdateEvent.UpdateType.CREATE)
         return xyz
@@ -124,8 +134,8 @@ object Waypoint {
         return oldFile.exists() && !file.exists()
     }
 
-    private fun dateFormatter(xyz: Coordinate, locationName: String): WaypointInfo {
+    private fun dateFormatter(xyz: Coordinate, locationName: String, type: Int): WaypointInfo {
         val date = sdf.format(Date())
-        return WaypointInfo(xyz, locationName, date)
+        return WaypointInfo(xyz, locationName, date, type)
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/util/WaypointInfo.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/WaypointInfo.kt
@@ -24,18 +24,34 @@ class WaypointInfo {
     @SerializedName("id")
     var id: Int
 
-    constructor(x: Int, y: Int, z: Int, nameSet: String, timeSet: String) {
+    @JvmField
+    @SerializedName("type")
+    var wpType: Int
+
+    /**
+     * Waypoint types:
+     * 0 - Waypoint
+     * 1 - LogSpot
+     * 2 - Stash
+     * 3 - TeleportSpot
+     * 4 - Other
+     * 5 - Death
+     */
+
+    constructor(x: Int, y: Int, z: Int, nameSet: String, timeSet: String, type: Int) {
         pos = Coordinate(x, y, z)
         name = nameSet
         date = timeSet
         id = genID()
+        wpType = type
     }
 
-    constructor(posSet: Coordinate, nameSet: String, timeSet: String) {
+    constructor(posSet: Coordinate, nameSet: String, timeSet: String, type: Int) {
         pos = posSet
         name = nameSet
         date = timeSet
         id = genID()
+        wpType = type
     }
 
     private fun genID(): Int {


### PR DESCRIPTION
**Describe the pull**
This adds an in game waypoint rendering with optional tracers. Waypoints can also be filtered through by waypoint types, so only specific types are rendered in game. The current types are: normal, logoutspot, stash, teleportspot, death, and other.

**Describe how this pull is helpful**
This is useful for visually seeing where your waypoints are and making it easier to get to get to them.

**Additional context**
This first attempt is a work in progress, as it only currently works in first person. I will continue working on getting it to work in third person. I couldn't think of a good way to group the different waypoints into types so if someone has suggestions I would gladly change the grouping.
