### PR TITLE
Fixed SelectionHighlight issue with Freecam in a smarter way

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/SelectionHighlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/SelectionHighlight.kt
@@ -7,7 +7,9 @@ import me.zeroeightsix.kami.setting.Settings
 import me.zeroeightsix.kami.util.ColourHolder
 import me.zeroeightsix.kami.util.ESPRenderer
 import me.zeroeightsix.kami.util.GeometryMasks
+import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.RayTraceResult.Type
+import kotlin.math.floor
 
 @Module.Info(
         name = "SelectionHighlight",
@@ -29,6 +31,9 @@ class SelectionHighlight : Module() {
     private val thickness = register(Settings.floatBuilder("LineThickness").withValue(2.0f).withRange(0.0f, 8.0f).build())
 
     override fun onWorldRender(event: RenderEvent) {
+        val eyePos = mc.player.getPositionEyes(event.partialTicks)
+        val eyeBlockPos = BlockPos(floor(eyePos.x), floor(eyePos.y), floor(eyePos.z))
+        if (!mc.world.isAirBlock(eyeBlockPos)) return
         val colour = ColourHolder(r.value, g.value, b.value)
         val hitObject = mc.objectMouseOver
         val renderer = ESPRenderer(event.partialTicks)

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/SelectionHighlight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/SelectionHighlight.kt
@@ -1,9 +1,7 @@
 package me.zeroeightsix.kami.module.modules.render
 
-import me.zeroeightsix.kami.KamiMod.MODULE_MANAGER
 import me.zeroeightsix.kami.event.events.RenderEvent
 import me.zeroeightsix.kami.module.Module
-import me.zeroeightsix.kami.module.modules.player.Freecam
 import me.zeroeightsix.kami.setting.Setting
 import me.zeroeightsix.kami.setting.Settings
 import me.zeroeightsix.kami.util.ColourHolder
@@ -29,10 +27,8 @@ class SelectionHighlight : Module() {
     private val aFilled = register(Settings.integerBuilder("FilledAlpha").withValue(63).withRange(0, 255).withVisibility { filled.value }.build())
     private val aOutline = register(Settings.integerBuilder("OutlineAlpha").withValue(200).withRange(0, 255).withVisibility { outline.value }.build())
     private val thickness = register(Settings.floatBuilder("LineThickness").withValue(2.0f).withRange(0.0f, 8.0f).build())
-    private val freecamDisable = register(Settings.b("FreecamDisable", true))
 
     override fun onWorldRender(event: RenderEvent) {
-        if (freecamDisable.value && MODULE_MANAGER.isModuleEnabled(Freecam::class.java)) return
         val colour = ColourHolder(r.value, g.value, b.value)
         val hitObject = mc.objectMouseOver
         val renderer = ESPRenderer(event.partialTicks)


### PR DESCRIPTION
**Describe the pull**
Checks if player eye position is in a block or not instead disabling it while Freecam is on

**Describe how this pull is helpful**
Remains functionality while Freecam on

**Additional context**
Add any other context about the pull here. 
