### PR TITLE
Added Potion Effects UI

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
@@ -6,6 +6,7 @@ import com.mojang.realmsclient.gui.ChatFormatting;
 import kotlin.Pair;
 import me.zeroeightsix.kami.KamiMod;
 import me.zeroeightsix.kami.gui.kami.component.ActiveModules;
+import me.zeroeightsix.kami.gui.kami.component.Potions;
 import me.zeroeightsix.kami.gui.kami.component.Radar;
 import me.zeroeightsix.kami.gui.kami.component.SettingsPanel;
 import me.zeroeightsix.kami.gui.kami.theme.kami.KamiTheme;
@@ -23,13 +24,10 @@ import me.zeroeightsix.kami.module.Module;
 import me.zeroeightsix.kami.module.modules.client.InfoOverlay;
 import me.zeroeightsix.kami.module.modules.movement.AutoWalk;
 import me.zeroeightsix.kami.util.Friends;
-import me.zeroeightsix.kami.util.LagCompensator;
 import me.zeroeightsix.kami.util.MathsUtils;
 import me.zeroeightsix.kami.util.Wrapper;
 import me.zeroeightsix.kami.util.colourUtils.ColourHolder;
-import me.zeroeightsix.kami.util.textUtils.RomanNumerals;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.*;
@@ -44,7 +42,6 @@ import javax.annotation.Nonnull;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static me.zeroeightsix.kami.KamiMod.MODULE_MANAGER;
@@ -214,38 +211,14 @@ public class KamiGUI extends GUI {
         frames.add(frame);
 
         /*
-         * Testing
+         * Potions
          */
-        /*
-        frame = new Frame(getTheme(), new Stretcherlayout(1), "Info2");
-        frame.setCloseable(false);
-        frame.setPinnable(true);
-//        Label information2 = new Label("");
-        EnumButton theme = new EnumButton("Theme", new String[] {"Modern", "Modern2", "Kami", "Kami Blue", "Custom"});
-        ColorizedCheckButton checkButton = new ColorizedCheckButton("Button");
-//        checkButton.addTickListener(() -> {
-//            if (checkButton.isFocused()) {
-//                sendChatMessage("focused");
-//            }
-//            else if (checkButton.isHovered()) {
-//                sendChatMessage("hovered");
-//            }
-//            else if (checkButton.isToggled()) {
-//                sendChatMessage("toggled");
-//            }
-//        });
-
-//        information.setShadow(true);
-//        information2.addTickListener(() -> {
-//            information2.setText("");
-//            information2.addLine(KamiMod.colour + "b" + KamiMod.KAMI_KANJI + KamiMod.colour + "3 " + KamiMod.MODVER);
-//            information2.addLine(KamiMod.colour + "b" + Math.round(LagCompensator.INSTANCE.getTickRate()) + KamiMod.colour + "3 tps");
-//            information2.addLine(KamiMod.colour + "b" + Minecraft.debugFPS + KamiMod.colour + "3 fps");
-//        });
-        frame.addChild(theme, checkButton);
-//        information2.setFontRenderer(fontRenderer);
-        frames.add(frame);
-        */
+        Frame frame2 = new Frame(getTheme(), new Stretcherlayout(1), "Potion Effects");
+        frame2.setCloseable(false);
+        frame2.setMinimizeable(true);
+        frame2.setPinnable(true);
+        frame2.addChild(new Potions());
+        frames.add(frame2);
 
         /*
          * Information Overlay / InfoOverlay
@@ -451,42 +424,6 @@ public class KamiGUI extends GUI {
         entityLabel.setShadow(true);
         entityLabel.setFontRenderer(fontRenderer);
         frames.add(frame);
-
-        /*
-         * Potion Effects
-         */
-        frame = new Frame(getTheme(), new Stretcherlayout(1), "Potions");
-        frame.setCloseable(false);
-        frame.setPinnable(true);
-        Label potionsLabel = new Label("");
-        potionsLabel.addTickListener(new TickListener() {
-            final Minecraft mc = Minecraft.getMinecraft();
-
-            @Override
-            public void onTick() {
-                potionsLabel.setText("");
-                if (mc.player == null) return;
-
-                // loop through potions and add them to the potions label
-                mc.player.getActivePotionMap().forEach((potion, potionEffect) -> {
-                    String name = I18n.format(potion.getName());
-                    String amplifier = RomanNumerals.INSTANCE.numberToRoman(potionEffect.getAmplifier() + 1); // add one because minecraft starts at 0
-                    long secDuration = new Float(potionEffect.getDuration() / LagCompensator.INSTANCE.getTickRate()).longValue();
-                    long min = TimeUnit.SECONDS.toMinutes(secDuration);
-                    long secs = TimeUnit.SECONDS.toSeconds(secDuration) - (min * 60);
-                    String potionText = String.format("%s %s (%d:%02d)", name, amplifier, min, secs);
-                    potionsLabel.addLine(potionText);
-                });
-
-            }
-        });
-
-        frame.addChild(potionsLabel);
-        potionsLabel.setFontRenderer(fontRenderer);
-        potionsLabel.setShadow(true);
-        frame.setMinimumWidth(80);
-        frames.add(frame);
-
 
         /*
          * Coordinates

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
@@ -27,6 +27,7 @@ import me.zeroeightsix.kami.util.Friends;
 import me.zeroeightsix.kami.util.MathsUtils;
 import me.zeroeightsix.kami.util.Wrapper;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.*;
@@ -41,6 +42,7 @@ import javax.annotation.Nonnull;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static me.zeroeightsix.kami.KamiMod.MODULE_MANAGER;
@@ -284,7 +286,7 @@ public class KamiGUI extends GUI {
         frame.setCloseable(false);
         frame.setPinnable(false);
         frame.setMinimizeable(true);
-        frame.setMinimumWidth(60);
+        frame.setMinimumWidth(80);
         frame.setMinimumHeight(10);
         Label friends = new Label("");
         friends.setShadow(true);
@@ -306,7 +308,7 @@ public class KamiGUI extends GUI {
         frame = new Frame(getTheme(), new Stretcherlayout(1), "Baritone");
         frame.setCloseable(false);
         frame.setPinnable(true);
-        frame.setMinimumWidth(70);
+        frame.setMinimumWidth(85);
         Label processes = new Label("");
         processes.setShadow(true);
 
@@ -394,7 +396,7 @@ public class KamiGUI extends GUI {
         });
         frame.setCloseable(false);
         frame.setPinnable(true);
-        frame.setMinimumWidth(75);
+        frame.setMinimumWidth(100);
         list.setShadow(true);
         frame.addChild(list);
         list.setFontRenderer(fontRenderer);
@@ -406,7 +408,7 @@ public class KamiGUI extends GUI {
         frame = new Frame(getTheme(), new Stretcherlayout(1), "Entities");
         Label entityLabel = new Label("");
         frame.setCloseable(false);
-        frame.setMinimumWidth(60);
+        frame.setMinimumWidth(80);
         Frame finalFrame1 = frame;
         entityLabel.addTickListener(new TickListener() {
             Minecraft mc = Wrapper.getMinecraft();
@@ -447,6 +449,56 @@ public class KamiGUI extends GUI {
         entityLabel.setShadow(true);
         entityLabel.setFontRenderer(fontRenderer);
         frames.add(frame);
+
+        /*
+         * Potion Effects
+         */
+        frame = new Frame(getTheme(), new Stretcherlayout(1), "Potions");
+        frame.setCloseable(false);
+        frame.setPinnable(true);
+        Label potionsLabel = new Label("");
+        potionsLabel.addTickListener(new TickListener() {
+            Minecraft mc = Minecraft.getMinecraft();
+
+            @Override
+            public void onTick() {
+                potionsLabel.setText("");
+
+                if(mc.player == null){
+                    return;
+                }
+
+                // loop through potions and add them to the potions label
+                mc.player.getActivePotionMap().forEach((potion, potionEffect) -> {
+                    String name = I18n.format(potion.getName());
+                    String amplifier;
+                    switch (potionEffect.getAmplifier()) {
+                        case 0:
+                            amplifier = "I";
+                            break;
+                        case 1:
+                            amplifier = "II";
+                            break;
+                        default:
+                            amplifier = "?";
+                            break;
+                    }
+                    int secDuration = potionEffect.getDuration() / 20; // 20 ticks per sec, this may be incorrect in laggy servers
+                    long min = TimeUnit.SECONDS.toMinutes(secDuration);
+                    long secs = TimeUnit.SECONDS.toSeconds(secDuration) - (min * 60);
+                    String potionText = String.format("%s %s (%d:%02d)", name, amplifier, min, secs);
+                    potionsLabel.addLine(potionText);
+                });
+
+            }
+        });
+
+        frame.addChild(potionsLabel);
+        potionsLabel.setFontRenderer(fontRenderer);
+        potionsLabel.setShadow(true);
+        frame.setMinimumWidth(80);
+        frames.add(frame);
+
 
         /*
          * Coordinates

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
@@ -22,6 +22,7 @@ import me.zeroeightsix.kami.gui.rgui.util.Docking;
 import me.zeroeightsix.kami.module.Module;
 import me.zeroeightsix.kami.module.modules.client.InfoOverlay;
 import me.zeroeightsix.kami.module.modules.movement.AutoWalk;
+import me.zeroeightsix.kami.util.LagCompensator;
 import me.zeroeightsix.kami.util.colourUtils.ColourHolder;
 import me.zeroeightsix.kami.util.Friends;
 import me.zeroeightsix.kami.util.MathsUtils;
@@ -483,7 +484,7 @@ public class KamiGUI extends GUI {
                             amplifier = "?";
                             break;
                     }
-                    int secDuration = potionEffect.getDuration() / 20; // 20 ticks per sec, this may be incorrect in laggy servers
+                    long secDuration = new Float(potionEffect.getDuration() / LagCompensator.INSTANCE.getTickRate()).longValue();
                     long min = TimeUnit.SECONDS.toMinutes(secDuration);
                     long secs = TimeUnit.SECONDS.toSeconds(secDuration) - (min * 60);
                     String potionText = String.format("%s %s (%d:%02d)", name, amplifier, min, secs);

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/KamiGUI.java
@@ -22,11 +22,12 @@ import me.zeroeightsix.kami.gui.rgui.util.Docking;
 import me.zeroeightsix.kami.module.Module;
 import me.zeroeightsix.kami.module.modules.client.InfoOverlay;
 import me.zeroeightsix.kami.module.modules.movement.AutoWalk;
-import me.zeroeightsix.kami.util.LagCompensator;
-import me.zeroeightsix.kami.util.colourUtils.ColourHolder;
 import me.zeroeightsix.kami.util.Friends;
+import me.zeroeightsix.kami.util.LagCompensator;
 import me.zeroeightsix.kami.util.MathsUtils;
 import me.zeroeightsix.kami.util.Wrapper;
+import me.zeroeightsix.kami.util.colourUtils.ColourHolder;
+import me.zeroeightsix.kami.util.textUtils.RomanNumerals;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.Entity;
@@ -459,31 +460,17 @@ public class KamiGUI extends GUI {
         frame.setPinnable(true);
         Label potionsLabel = new Label("");
         potionsLabel.addTickListener(new TickListener() {
-            Minecraft mc = Minecraft.getMinecraft();
+            final Minecraft mc = Minecraft.getMinecraft();
 
             @Override
             public void onTick() {
                 potionsLabel.setText("");
-
-                if(mc.player == null){
-                    return;
-                }
+                if (mc.player == null) return;
 
                 // loop through potions and add them to the potions label
                 mc.player.getActivePotionMap().forEach((potion, potionEffect) -> {
                     String name = I18n.format(potion.getName());
-                    String amplifier;
-                    switch (potionEffect.getAmplifier()) {
-                        case 0:
-                            amplifier = "I";
-                            break;
-                        case 1:
-                            amplifier = "II";
-                            break;
-                        default:
-                            amplifier = "?";
-                            break;
-                    }
+                    String amplifier = RomanNumerals.INSTANCE.numberToRoman(potionEffect.getAmplifier() + 1); // add one because minecraft starts at 0
                     long secDuration = new Float(potionEffect.getDuration() / LagCompensator.INSTANCE.getTickRate()).longValue();
                     long min = TimeUnit.SECONDS.toMinutes(secDuration);
                     long secs = TimeUnit.SECONDS.toSeconds(secDuration) - (min * 60);

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/component/Potions.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/component/Potions.java
@@ -1,0 +1,30 @@
+package me.zeroeightsix.kami.gui.kami.component;
+
+import me.zeroeightsix.kami.gui.rgui.component.container.use.Frame;
+import me.zeroeightsix.kami.gui.rgui.component.listen.RenderListener;
+import me.zeroeightsix.kami.gui.rgui.component.use.Label;
+import me.zeroeightsix.kami.gui.rgui.util.ContainerHelper;
+import me.zeroeightsix.kami.gui.rgui.util.Docking;
+
+public class Potions extends Label {
+    public boolean sort_up = true;
+
+    public Potions() {
+        super("");
+
+        addRenderListener(new RenderListener() {
+            @Override
+            public void onPreRender() {
+                Frame parentFrame = ContainerHelper.getFirstParent(Frame.class, Potions.this);
+                if (parentFrame == null) return;
+                Docking docking = parentFrame.getDocking();
+                if (docking.isTop()) sort_up = true;
+                if (docking.isBottom()) sort_up = false;
+            }
+
+            @Override
+            public void onPostRender() {
+            }
+        });
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiPotionUi.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiPotionUi.java
@@ -1,0 +1,87 @@
+package me.zeroeightsix.kami.gui.kami.theme.kami;
+
+import me.zeroeightsix.kami.gui.kami.component.Potions;
+import me.zeroeightsix.kami.gui.rgui.component.AlignedComponent;
+import me.zeroeightsix.kami.gui.rgui.render.AbstractComponentUI;
+import me.zeroeightsix.kami.gui.rgui.render.font.FontRenderer;
+import me.zeroeightsix.kami.util.PotionInfo;
+import me.zeroeightsix.kami.util.Wrapper;
+import me.zeroeightsix.kami.util.colourUtils.ColourConverter;
+import me.zeroeightsix.kami.util.colourUtils.ColourHolder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.lwjgl.opengl.GL11.GL_BLEND;
+import static org.lwjgl.opengl.GL11.glDisable;
+
+public class KamiPotionUi extends AbstractComponentUI<Potions> {
+
+    @Override
+    public void renderComponent(Potions component, FontRenderer f) {
+        final Minecraft mc = Minecraft.getMinecraft();
+        if (mc.player == null) return;
+
+        FontRenderer renderer = Wrapper.getFontRenderer();
+        int y = 2;
+        GlStateManager.pushMatrix();
+        GL11.glDisable(GL11.GL_CULL_FACE);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+
+        List<PotionInfo> potions = new ArrayList<>();
+        mc.player.getActivePotionMap().forEach((potion, potionEffect) -> potions.add(new PotionInfo(
+                I18n.format(potion.getName()),
+                potionEffect.getAmplifier(),
+                potionEffect
+        )));
+
+        Collection<PotionInfo> sortedPotions = potions.stream().sorted(Comparator.comparing(potion -> renderer.getStringWidth(potion.formattedName(true)) * (component.sort_up ? -1 : 1))).collect(Collectors.toList());
+
+        Function<Integer, Integer> xFunc;
+        switch (component.getAlignment()) {
+            case RIGHT:
+                xFunc = i -> component.getWidth() - i;
+                break;
+            case CENTER:
+                xFunc = i -> component.getWidth() / 2 - i / 2;
+                break;
+            case LEFT:
+            default:
+                xFunc = i -> 0;
+                break;
+        }
+
+
+        for (PotionInfo potion : potions) {
+            int color = potion.getPotionEffect().getPotion().getLiquidColor();
+            ColourHolder ch = ColourConverter.intToRgb(color);
+            String text = potion.formattedName(component.getAlignment().equals(AlignedComponent.Alignment.RIGHT));
+            int textWidth = renderer.getStringWidth(text);
+            int textHeight = renderer.getFontHeight() + 1;
+            renderer.drawStringWithShadow(xFunc.apply(textWidth), y, ch.getR(), ch.getG(), ch.getB(), text);
+            y += textHeight;
+        }
+
+        component.setHeight(2);
+
+        GL11.glEnable(GL11.GL_CULL_FACE);
+        glDisable(GL_BLEND);
+        GlStateManager.popMatrix();
+
+    }
+
+    @Override
+    public void handleSizeComponent(Potions component) {
+        component.setWidth(100);
+        component.setHeight(100);
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiTheme.java
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/kami/KamiTheme.java
@@ -27,6 +27,7 @@ public class KamiTheme extends AbstractTheme {
         installUI(new RootChatUI());
         installUI(new RootCheckButtonUI());
         installUI(new KamiActiveModulesUI());
+        installUI(new KamiPotionUi());
         installUI(new KamiSettingsPanelUI());
         installUI(new RootSliderUI());
         installUI(new KamiEnumButtonUI());

--- a/src/main/java/me/zeroeightsix/kami/util/PotionInfo.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/PotionInfo.kt
@@ -1,0 +1,37 @@
+package me.zeroeightsix.kami.util
+
+import me.zeroeightsix.kami.KamiMod
+import me.zeroeightsix.kami.util.textUtils.RomanNumerals
+import net.minecraft.potion.PotionEffect
+import java.util.concurrent.TimeUnit
+
+data class PotionInfo(val name: String, val amplifier: Int, val potionEffect: PotionEffect) {
+    /**
+     * (min:secs)
+     */
+    fun formattedTimeLeft(): String {
+        val compensatedDuration: Long = potionEffect.duration / LagCompensator.INSTANCE.tickRate.toLong()
+        val min = TimeUnit.SECONDS.toMinutes(compensatedDuration)
+        val secs = TimeUnit.SECONDS.toSeconds(compensatedDuration) - min * 60
+        return String.format("(%d:%02d)", min, secs)
+    }
+
+    /**
+     * Returns the fully formatted potion name without the time
+     * Speed II
+     */
+    fun formattedName(): String {
+        return "$name ${RomanNumerals.numberToRoman(amplifier + 1)}"
+    }
+
+    /**
+     * Formats name and time based on UI alignment
+     */
+    fun formattedName(right: Boolean): String {
+        return if (right) {
+            "${KamiMod.colour}7${formattedTimeLeft()}${KamiMod.colour}r ${formattedName()}"
+        } else {
+            "${formattedName()} ${KamiMod.colour}7${formattedTimeLeft()}"
+        }
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/util/textUtils/RomanNumerals.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/textUtils/RomanNumerals.kt
@@ -1,0 +1,19 @@
+package me.zeroeightsix.kami.util.textUtils
+
+object RomanNumerals {
+    fun numberToRoman(number: Int): String {
+        return when (number) {
+            1 -> "I"
+            2 -> "II"
+            3 -> "III"
+            4 -> "IV"
+            5 -> "V"
+            6 -> "VI"
+            7 -> "VII"
+            8 -> "VIII"
+            9 -> "IX"
+            10 -> "X"
+            else -> number.toString()
+        }
+    }
+}


### PR DESCRIPTION
**Describe the pull**
Adds an area where active potion effects are listed.
Changed a few minimum widths so that pins and expand/collapse buttons do not overlap text.

**Describe how this pull is helpful**
Resolves #707 
Makes the GUI a bit nicer to look at and interact with.

**Additional context**
I was considering using the primary and secondary colors chosen by the player in `InfoOverlay` but I was unsure if the colors were intended to apply to all parts of the GUI or only that specific section. It would be useful if each label had a primary and secondary color that could be used freely. Maybe add it to the GUI todo list?
