### PR TITLE
Made EntitySpeed flight option works for boat, added primary passenger check

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/EntitySpeed.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/EntitySpeed.kt
@@ -14,6 +14,7 @@ import kotlin.math.sin
 
 /**
  * Created by 086 on 16/12/2017.
+ * Updated by littlebroto1 on 06/09/2020. (DD-MM-YYYY)
  */
 @Module.Info(
         name = "EntitySpeed",
@@ -31,7 +32,7 @@ class EntitySpeed : Module() {
             val riding = mc.player.getRidingEntity()
             if (riding is EntityPig || riding is AbstractHorse) {
                 steerEntity(riding)
-            } else if (riding is EntityBoat) {
+            } else if (riding is EntityBoat && riding.controllingPassenger == mc.player) {
                 steerBoat(boat)
             }
         }
@@ -60,8 +61,8 @@ class EntitySpeed : Module() {
         val right = mc.gameSettings.keyBindRight.isKeyDown
         val back = mc.gameSettings.keyBindBack.isKeyDown
 
-        if (!(forward && back)) boat.motionY = 0.0
-        if (mc.gameSettings.keyBindJump.isKeyDown) boat.motionY += speed.value / 2f.toDouble()
+        if (!(forward && back)&&flight.value) boat.motionY = 0.0
+        if (mc.gameSettings.keyBindJump.isKeyDown&&flight.value) boat.motionY += speed.value / 2f.toDouble()
         if (!forward && !left && !right && !back) return
         if (left && right) angle = if (forward) 0 else if (back) 180 else -1 else if (forward && back) angle = if (left) -90 else if (right) 90 else -1 else {
             angle = if (left) -90 else if (right) 90 else 0
@@ -81,7 +82,7 @@ class EntitySpeed : Module() {
     }
 
     private val boat: EntityBoat?
-        get() = if (mc.player.getRidingEntity() != null && mc.player.getRidingEntity() is EntityBoat) mc.player.getRidingEntity() as EntityBoat? else null
+        get() = if (mc.player.getRidingEntity() != null && mc.player.getRidingEntity() is EntityBoat && (mc.player.getRidingEntity() as EntityBoat).controllingPassenger == mc.player) mc.player.getRidingEntity() as EntityBoat? else null
 
     private fun moveForward(entity: Entity?, speed: Double) {
         if (entity != null) {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/EntitySpeed.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/EntitySpeed.kt
@@ -61,8 +61,10 @@ class EntitySpeed : Module() {
         val right = mc.gameSettings.keyBindRight.isKeyDown
         val back = mc.gameSettings.keyBindBack.isKeyDown
 
-        if (!(forward && back)&&flight.value) boat.motionY = 0.0
-        if (mc.gameSettings.keyBindJump.isKeyDown&&flight.value) boat.motionY += speed.value / 2f.toDouble()
+        if (flight.value) {
+            if (!(forward && back)) boat.motionY = 0.0
+            if (mc.gameSettings.keyBindJump.isKeyDown) boat.motionY += speed.value / 2f.toDouble()
+        }
         if (!forward && !left && !right && !back) return
         if (left && right) angle = if (forward) 0 else if (back) 180 else -1 else if (forward && back) angle = if (left) -90 else if (right) 90 else -1 else {
             angle = if (left) -90 else if (right) 90 else 0


### PR DESCRIPTION
**Describe the pull**
This pull should make so that boats abide by the Flight setting when using the EntitySpeed module. It should also make so that secondary passengers won't attempt to control boats since it is not possible.

**Describe how this pull is helpful**
Currently, people have no option to disable flight for boats which can cause them to be kicked or banned for flying when they would not be so otherwise.