### PR TITLE
PingSpoof

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/PingSpoof.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/PingSpoof.kt
@@ -1,0 +1,35 @@
+package me.zeroeightsix.kami.module.modules.misc
+
+import me.zero.alpine.listener.EventHandler
+import me.zero.alpine.listener.EventHook
+import me.zero.alpine.listener.Listener
+import me.zeroeightsix.kami.event.events.PacketEvent
+import me.zeroeightsix.kami.module.Module
+import me.zeroeightsix.kami.setting.Settings
+import net.minecraft.network.play.client.CPacketKeepAlive
+import net.minecraft.network.play.server.SPacketKeepAlive
+import java.util.*
+
+@Module.Info(
+        name = "PingSpoof",
+        category = Module.Category.MISC,
+        description = "Cancels or adds delay to your ping packets"
+)
+class PingSpoof : Module() {
+    private val cancel = register(Settings.b("Cancel", false))// most servers will kick/time you out for this
+    private val delay = register(Settings.integerBuilder("Delay").withValue(400).withMinimum(0).withMaximum(4000).withVisibility { !cancel.value }.build())
+
+    @EventHandler
+    private val receiveListener = Listener(EventHook { event: PacketEvent.Receive ->
+        if (event.packet is SPacketKeepAlive) {
+            event.cancel()
+            if (!cancel.value)
+                Timer().schedule(
+                        object : TimerTask() {
+                            override fun run() {
+                                mc.connection.let { it!!.sendPacket(CPacketKeepAlive((event.packet as SPacketKeepAlive).id)) }
+                            }
+                        }, delay.value.toLong())
+        }
+    })
+}

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/PingSpoof.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/PingSpoof.kt
@@ -17,19 +17,19 @@ import java.util.*
 )
 class PingSpoof : Module() {
     private val cancel = register(Settings.b("Cancel", false))// most servers will kick/time you out for this
-    private val delay = register(Settings.integerBuilder("Delay").withValue(400).withMinimum(0).withMaximum(4000).withVisibility { !cancel.value }.build())
+    private val delay = register(Settings.integerBuilder("Delay").withValue(100).withRange(0, 2000).withVisibility { !cancel.value }.build())
 
     @EventHandler
     private val receiveListener = Listener(EventHook { event: PacketEvent.Receive ->
         if (event.packet is SPacketKeepAlive) {
             event.cancel()
-            if (!cancel.value)
-                Timer().schedule(
-                        object : TimerTask() {
-                            override fun run() {
-                                mc.connection.let { it!!.sendPacket(CPacketKeepAlive((event.packet as SPacketKeepAlive).id)) }
-                            }
-                        }, delay.value.toLong())
+            if (!cancel.value) {
+                Timer().schedule(object : TimerTask() {
+                    override fun run() {
+                        mc.connection.let { it!!.sendPacket(CPacketKeepAlive(event.packet.id)) }
+                    }
+                }, delay.value.toLong())
+            }
         }
     })
 }


### PR DESCRIPTION
**Describe the pull**
Adds a way to increase your ping artificially. Decreasing your ping would be harder as you would have to guess a number 
that is the one from the last packet +15000(+-)100.
Issue #1301 only talked about increasing so this is fine.
I haven't found a sever on which canceling the packets didn't kick you after 30sec, but i've heard there are some which dont kick you.

**Describe how this pull is helpful**
idk ngl 

