### PR TITLE
[feature] Shader ESP 

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/ESP.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/ESP.kt
@@ -50,15 +50,15 @@ object ESP : Module() {
     private val range = register(Settings.integerBuilder("Range").withValue(64).withRange(1, 128).withVisibility { page.value == Page.ENTITY_TYPE }.build())
 
     /* Rendering settings */
-    private val mode = register(Settings.enumBuilder(ESPMode::class.java, "Mode").withValue(ESPMode.BOX).withVisibility { page.value == Page.RENDERING }.build())
+    private val mode = register(Settings.enumBuilder(ESPMode::class.java, "Mode").withValue(ESPMode.SHADER).withVisibility { page.value == Page.RENDERING }.build())
     private val hideOriginal = register(Settings.booleanBuilder("HideOriginal").withValue(false).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.SHADER }.build())
     private val filled = register(Settings.booleanBuilder("Filled").withValue(false).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
     private val outline = register(Settings.booleanBuilder("Outline").withValue(true).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
-    private val r = register(Settings.integerBuilder("Red").withValue(155).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
-    private val g = register(Settings.integerBuilder("Green").withValue(144).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
-    private val b = register(Settings.integerBuilder("Blue").withValue(255).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
-    private val aFilled = register(Settings.integerBuilder("FilledAlpha").withValue(63).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
-    private val aOutline = register(Settings.integerBuilder("OutlineAlpha").withValue(255).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val r = register(Settings.integerBuilder("Red").withValue(155).withRange(0, 255).withStep(1).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val g = register(Settings.integerBuilder("Green").withValue(144).withRange(0, 255).withStep(1).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val b = register(Settings.integerBuilder("Blue").withValue(255).withRange(0, 255).withStep(1).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val aFilled = register(Settings.integerBuilder("FilledAlpha").withValue(63).withRange(0, 255).withStep(1).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val aOutline = register(Settings.integerBuilder("OutlineAlpha").withValue(255).withRange(0, 255).withStep(1).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
     private val blurRadius = register(Settings.floatBuilder("BlurRadius").withValue(0f).withRange(0f, 16f).withStep(0.5f).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.SHADER }.build())
     private val width = register(Settings.floatBuilder("Width").withValue(2f).withRange(1f, 8f).withStep(0.25f).withVisibility { page.value == Page.RENDERING }.build())
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/ESP.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/ESP.kt
@@ -1,19 +1,30 @@
 package me.zeroeightsix.kami.module.modules.render
 
+import me.zero.alpine.listener.EventHandler
+import me.zero.alpine.listener.EventHook
+import me.zero.alpine.listener.Listener
+import me.zeroeightsix.kami.KamiMod
+import me.zeroeightsix.kami.event.events.RenderEntityEvent
 import me.zeroeightsix.kami.event.events.RenderEvent
 import me.zeroeightsix.kami.module.Module
 import me.zeroeightsix.kami.setting.Setting
 import me.zeroeightsix.kami.setting.Settings
 import me.zeroeightsix.kami.util.EntityUtils.getTargetList
+import me.zeroeightsix.kami.util.color.ColorConverter
 import me.zeroeightsix.kami.util.color.ColorHolder
 import me.zeroeightsix.kami.util.graphics.ESPRenderer
-import net.minecraft.client.shader.Shader
+import me.zeroeightsix.kami.util.graphics.KamiTessellator
+import net.minecraft.client.renderer.GlStateManager
+import net.minecraft.client.renderer.OpenGlHelper
+import net.minecraft.client.shader.Framebuffer
+import net.minecraft.client.shader.ShaderGroup
+import net.minecraft.client.shader.ShaderLinkHelper
 import net.minecraft.entity.Entity
 import net.minecraft.entity.item.EntityItem
 import net.minecraft.entity.item.EntityXPOrb
 import net.minecraft.entity.projectile.EntityArrow
 import net.minecraft.entity.projectile.EntityThrowable
-import java.util.function.Consumer
+import net.minecraft.util.ResourceLocation
 
 @Module.Info(
         name = "ESP",
@@ -40,40 +51,117 @@ object ESP : Module() {
     private val range = register(Settings.integerBuilder("Range").withValue(64).withRange(1, 128).withVisibility { page.value == Page.ENTITY_TYPE }.build())
 
     /* Rendering settings */
-    private val mode = register(Settings.enumBuilder(ESPMode::class.java).withName("Mode").withValue(ESPMode.BOX).withVisibility { page.value == Page.RENDERING }.build())
-    private val radiusValue = register(Settings.integerBuilder("Width").withMinimum(1).withMaximum(100).withValue(25).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.GLOW }.build())
-    private val filled = register(Settings.booleanBuilder("Filled").withValue(false).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val outline = register(Settings.booleanBuilder("Outline").withValue(true).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val r = register(Settings.integerBuilder("Red").withValue(155).withRange(0, 255).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val g = register(Settings.integerBuilder("Green").withValue(144).withRange(0, 255).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val b = register(Settings.integerBuilder("Blue").withValue(255).withRange(0, 255).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val aFilled = register(Settings.integerBuilder("FilledAlpha").withValue(63).withRange(0, 255).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val aOutline = register(Settings.integerBuilder("OutlineAlpha").withValue(127).withRange(0, 255).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
-    private val thickness = register(Settings.floatBuilder("Thickness").withValue(2.0f).withRange(0.0f, 8.0f).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.BOX }.build())
+    private val mode = register(Settings.enumBuilder(ESPMode::class.java, "Mode").withValue(ESPMode.BOX).withVisibility { page.value == Page.RENDERING }.build())
+    private val hideOriginal = register(Settings.booleanBuilder("HideOriginal").withValue(false).withVisibility { page.value == Page.RENDERING && mode.value == ESPMode.SHADER }.build())
+    private val filled = register(Settings.booleanBuilder("Filled").withValue(false).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val outline = register(Settings.booleanBuilder("Outline").withValue(true).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val r = register(Settings.integerBuilder("Red").withValue(155).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val g = register(Settings.integerBuilder("Green").withValue(144).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val b = register(Settings.integerBuilder("Blue").withValue(255).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val aFilled = register(Settings.integerBuilder("FilledAlpha").withValue(63).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val aOutline = register(Settings.integerBuilder("OutlineAlpha").withValue(255).withRange(0, 255).withVisibility { page.value == Page.RENDERING && (mode.value == ESPMode.BOX || mode.value == ESPMode.SHADER) }.build())
+    private val width = register(Settings.floatBuilder("Width").withValue(2f).withRange(1f, 8f).withStep(0.25f).withVisibility { page.value == Page.RENDERING }.build())
 
     private enum class Page {
         ENTITY_TYPE, RENDERING
     }
 
     private enum class ESPMode {
-        BOX, GLOW
+        BOX, GLOW, SHADER
     }
 
-    private var entityList: Array<Entity>? = null
+    private val entityList = HashSet<Entity>()
+
+    private val shader: ShaderGroup?
+    private val frameBuffer: Framebuffer?
+    private var prevWidth = mc.displayWidth
+    private var prevHeight = mc.displayHeight
+
+    init {
+        mode.settingListener = Setting.SettingListeners {
+            resetGlow()
+        }
+
+        shader = if (OpenGlHelper.shadersSupported) {
+            try {
+                val resourceLocation = ResourceLocation("shaders/post/esp_outline.json")
+                ShaderLinkHelper.setNewStaticShaderLinkHelper()
+                ShaderGroup(mc.textureManager, mc.resourceManager, mc.framebuffer, resourceLocation).also {
+                    it.createBindFramebuffers(mc.displayWidth, mc.displayHeight)
+                }
+            } catch (e: Exception) {
+                KamiMod.log.warn("$chatName Failed loading Shader")
+                e.printStackTrace()
+                null
+            }.also {
+                frameBuffer = it?.getFramebufferRaw("final")
+            }
+        } else {
+            frameBuffer = null
+            null
+        }
+    }
+
+    @EventHandler
+    private val preRenderListener = Listener(EventHook { event: RenderEntityEvent.Pre ->
+        if (mode.value != ESPMode.SHADER || event.entity == null || mc.renderManager.renderOutlines || !entityList.contains(event.entity)) return@EventHook
+        if (hideOriginal.value) {
+            // Steal it from Minecraft rendering kek
+            prepareFrameBuffer()
+        }
+    })
+
+    @EventHandler
+    private val postRenderListener = Listener(EventHook { event: RenderEntityEvent.Post ->
+        if (mode.value != ESPMode.SHADER || event.entity == null || mc.renderManager.renderOutlines || !entityList.contains(event.entity)) return@EventHook
+        if (!hideOriginal.value) {
+            prepareFrameBuffer()
+            mc.renderManager.getEntityRenderObject<Entity>(event.entity)?.doRender(event.entity, event.x, event.y, event.z, event.yaw, event.partialTicks)
+        }
+
+        mc.framebuffer.bindFramebuffer(false)
+        GlStateManager.disableOutlineMode()
+        GlStateManager.popMatrix()
+    })
+
+    private fun prepareFrameBuffer() {
+        GlStateManager.pushMatrix()
+        GlStateManager.enableOutlineMode(ColorConverter.rgbToInt(r.value, g.value, b.value, aOutline.value))
+        frameBuffer?.bindFramebuffer(false)
+    }
 
     override fun onWorldRender(event: RenderEvent) {
-        if (mc.renderManager.options == null || entityList == null) return
+        if (mc.renderManager.options == null) return
         when (mode.value) {
             ESPMode.BOX -> {
                 val colour = ColorHolder(r.value, g.value, b.value)
                 val renderer = ESPRenderer()
                 renderer.aFilled = if (filled.value) aFilled.value else 0
                 renderer.aOutline = if (outline.value) aOutline.value else 0
-                renderer.thickness = thickness.value
-                for (e in entityList!!) {
-                    renderer.add(e, colour)
+                renderer.thickness = width.value
+                for (entity in entityList) {
+                    renderer.add(entity, colour)
                 }
                 renderer.render(true)
+            }
+
+            ESPMode.SHADER -> {
+                // Apply shader on the frame buffer
+                frameBuffer?.bindFramebuffer(false)
+                shader?.render(KamiTessellator.pTicks())
+
+                // Draw it on the main frame buffer
+                mc.framebuffer.bindFramebuffer(false)
+                GlStateManager.disableDepth()
+                // Re-enable blend because shader rendering will disable it at the end
+                GlStateManager.enableBlend()
+                frameBuffer?.framebufferRenderExt(mc.displayWidth, mc.displayHeight, false)
+                GlStateManager.disableBlend()
+                GlStateManager.enableDepth()
+
+                // Clean up the frame buffer
+                frameBuffer?.framebufferClear()
+                mc.framebuffer.bindFramebuffer(false)
             }
 
             else -> {
@@ -83,27 +171,40 @@ object ESP : Module() {
     }
 
     override fun onUpdate() {
-        entityList = getEntityList()
+        // Refresh frame buffer on resolution change
+        if (prevWidth != mc.displayWidth || prevHeight != mc.displayHeight){
+            prevWidth = mc.displayWidth
+            prevHeight = mc.displayHeight
+            shader?.createBindFramebuffers(mc.displayWidth, mc.displayHeight)
+        }
+
+        entityList.clear()
+        entityList.addAll(getEntityList())
 
         if (mode.value == ESPMode.GLOW) {
-            if (entityList?.isNotEmpty() == true) {
-                mc.renderGlobal.entityOutlineShader.listShaders.forEach(Consumer { shader: Shader ->
-                    shader.shaderManager.getShaderUniform("Radius")?.set(radiusValue.value / 50f)
-                })
-                for (e in mc.world.loadedEntityList) { // Set grow for entities in the list. Remove grow for entities not in the list
-                    e.isGlowing = entityList!!.contains(e)
+            if (entityList.isNotEmpty()) {
+                for (shader in mc.renderGlobal.entityOutlineShader.listShaders) {
+                    shader.shaderManager.getShaderUniform("Radius")?.set(width.value)
+                }
+
+                for (entity in mc.world.loadedEntityList) { // Set grow for entities in the list. Remove grow for entities not in the list
+                    entity.isGlowing = entityList.contains(entity)
                 }
             } else {
                 resetGlow()
             }
+        } else if (mode.value == ESPMode.SHADER) {
+            shader?.let {
+                for (shader in it.listShaders) {
+                    shader.shaderManager.getShaderUniform("width")?.set(width.value)
+                    shader.shaderManager.getShaderUniform("outlineAlpha")?.set(if (outline.value) aOutline.value / 255f else 0f)
+                    shader.shaderManager.getShaderUniform("filledAlpha")?.set(if (filled.value) aFilled.value / 255f else 0f)
+                }
+            }
         }
     }
 
-    public override fun onDisable() {
-        resetGlow()
-    }
-
-    private fun getEntityList(): Array<Entity> {
+    private fun getEntityList(): List<Entity> {
         val player = arrayOf(players.value, friends.value, sleeping.value)
         val mob = arrayOf(mobs.value, passive.value, neutral.value, hostile.value)
         val entityList = ArrayList<Entity>()
@@ -126,24 +227,22 @@ object ESP : Module() {
                 }
             }
         }
-        return entityList.toTypedArray()
+        return entityList
+    }
+
+    override fun onDisable() {
+        resetGlow()
     }
 
     private fun resetGlow() {
         if (mc.player == null) return
-        mc.renderGlobal.entityOutlineShader.listShaders.forEach(Consumer { shader: Shader ->
-            val radius = shader.shaderManager.getShaderUniform("Radius")
-            radius?.set(2f) // default radius
-        })
-        for (e in mc.world.loadedEntityList) {
-            e.isGlowing = false
-        }
-        mc.player.isGlowing = false
-    }
 
-    init {
-        mode.settingListener = Setting.SettingListeners {
-            resetGlow()
+        for (shader in mc.renderGlobal.entityOutlineShader.listShaders) {
+            shader.shaderManager.getShaderUniform("Radius")?.set(2f) // default radius
+        }
+
+        for (entity in mc.world.loadedEntityList) {
+            entity.isGlowing = false
         }
     }
 }

--- a/src/main/resources/assets/minecraft/shaders/post/esp_outline.json
+++ b/src/main/resources/assets/minecraft/shaders/post/esp_outline.json
@@ -16,7 +16,7 @@
                 },
                 {
                     "name": "Radius",
-                    "values": [ 16.0 ]
+                    "values": [ 2.0 ]
                 }
             ]
         },
@@ -31,7 +31,7 @@
                 },
                 {
                     "name": "Radius",
-                    "values": [ 16.0 ]
+                    "values": [ 2.0 ]
                 }
             ]
         },

--- a/src/main/resources/assets/minecraft/shaders/post/esp_outline.json
+++ b/src/main/resources/assets/minecraft/shaders/post/esp_outline.json
@@ -1,17 +1,54 @@
 {
     "targets": [
         "swap",
+        "previous",
         "final"
     ],
     "passes": [
         {
-            "name": "esp_outline",
-            "intarget": "final",
+            "name": "blur",
+            "intarget": "minecraft:main",
             "outtarget": "swap",
             "uniforms": [
                 {
-                    "name": "width",
-                    "values": [ 1.0 ]
+                    "name": "BlurDir",
+                    "values": [ 1.0, 0.0 ]
+                },
+                {
+                    "name": "Radius",
+                    "values": [ 16.0 ]
+                }
+            ]
+        },
+        {
+            "name": "blur",
+            "intarget": "swap",
+            "outtarget": "previous",
+            "uniforms": [
+                {
+                    "name": "BlurDir",
+                    "values": [ 0.0, 1.0 ]
+                },
+                {
+                    "name": "Radius",
+                    "values": [ 16.0 ]
+                }
+            ]
+        },
+        {
+            "name": "esp_outline",
+            "intarget": "final",
+            "outtarget": "swap",
+            "auxtargets": [
+                {
+                    "name": "PrevSampler",
+                    "id": "previous"
+                }
+            ],
+            "uniforms": [
+                {
+                    "name": "color",
+                    "values": [ 0.6078, 0.5647, 1.0 ]
                 },
                 {
                     "name": "outlineAlpha",
@@ -20,6 +57,10 @@
                 {
                     "name": "filledAlpha",
                     "values": [ 0.25 ]
+                },
+                {
+                    "name": "width",
+                    "values": [ 1.0 ]
                 }
             ]
         },

--- a/src/main/resources/assets/minecraft/shaders/post/esp_outline.json
+++ b/src/main/resources/assets/minecraft/shaders/post/esp_outline.json
@@ -1,0 +1,32 @@
+{
+    "targets": [
+        "swap",
+        "final"
+    ],
+    "passes": [
+        {
+            "name": "esp_outline",
+            "intarget": "final",
+            "outtarget": "swap",
+            "uniforms": [
+                {
+                    "name": "width",
+                    "values": [ 1.0 ]
+                },
+                {
+                    "name": "outlineAlpha",
+                    "values": [ 1.0 ]
+                },
+                {
+                    "name": "filledAlpha",
+                    "values": [ 0.25 ]
+                }
+            ]
+        },
+        {
+            "name": "blit",
+            "intarget": "swap",
+            "outtarget": "final"
+        }
+    ]
+}

--- a/src/main/resources/assets/minecraft/shaders/program/esp_outline.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/esp_outline.fsh
@@ -1,13 +1,15 @@
 #version 120
 
 uniform sampler2D DiffuseSampler;
+uniform sampler2D PrevSampler;
 
 varying vec2 texCoord;
 varying vec2 oneTexel;
 
-uniform float width;
+uniform vec3 color;
 uniform float outlineAlpha;
 uniform float filledAlpha;
+uniform float width;
 
 void main(){
     int intWidth = int(width);
@@ -21,13 +23,17 @@ void main(){
                 vec4 sampleColor = texture2D(DiffuseSampler, texCoord + sampleCoord);
                 if (sampleColor.a > 0.0) {
                     // If we find a pixel that isn't transparent, set the frag color to it and replace the alpha.
-                    center = vec4(sampleColor.rgb, outlineAlpha);
+                    center = vec4(color, outlineAlpha);
                 }
             }
         }
     } else {
-        // Replace filled alpha
-        center = vec4(center.rgb, filledAlpha);
+        // Replace the color
+        center = vec4(color, 1.0);
+
+        // Mix it with the blured background
+        vec4 backgroundColor = texture2D(PrevSampler, texCoord);
+        center = mix(backgroundColor, center, filledAlpha);
     }
 
     gl_FragColor = center;

--- a/src/main/resources/assets/minecraft/shaders/program/esp_outline.fsh
+++ b/src/main/resources/assets/minecraft/shaders/program/esp_outline.fsh
@@ -1,0 +1,34 @@
+#version 120
+
+uniform sampler2D DiffuseSampler;
+
+varying vec2 texCoord;
+varying vec2 oneTexel;
+
+uniform float width;
+uniform float outlineAlpha;
+uniform float filledAlpha;
+
+void main(){
+    int intWidth = int(width);
+    vec4 center = texture2D(DiffuseSampler, texCoord);
+
+    if (center.a == 0.0) {
+        // Scan pixels nearby
+        for (int sampleX = -intWidth; sampleX <= intWidth; sampleX++) {
+            for (int sampleY = -intWidth; sampleY <= intWidth; sampleY++) {
+                vec2 sampleCoord = vec2(float(sampleX), float(sampleY)) * oneTexel;
+                vec4 sampleColor = texture2D(DiffuseSampler, texCoord + sampleCoord);
+                if (sampleColor.a > 0.0) {
+                    // If we find a pixel that isn't transparent, set the frag color to it and replace the alpha.
+                    center = vec4(sampleColor.rgb, outlineAlpha);
+                }
+            }
+        }
+    } else {
+        // Replace filled alpha
+        center = vec4(center.rgb, filledAlpha);
+    }
+
+    gl_FragColor = center;
+}

--- a/src/main/resources/assets/minecraft/shaders/program/esp_outline.json
+++ b/src/main/resources/assets/minecraft/shaders/program/esp_outline.json
@@ -8,14 +8,16 @@
     "fragment": "esp_outline",
     "attributes": [ "Position" ],
     "samplers": [
-        { "name": "DiffuseSampler" }
+        { "name": "DiffuseSampler" },
+        { "name": "PrevSampler" }
     ],
     "uniforms": [
         { "name": "ProjMat",      "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
         { "name": "InSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
         { "name": "OutSize",      "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
-        { "name": "width",        "type": "float",     "count": 1,  "values": [ 1.0 ] },
+        { "name": "color",        "type": "float",     "count": 3,  "values": [ 1.0, 1.0, 1.0 ] },
         { "name": "outlineAlpha", "type": "float",     "count": 1,  "values": [ 1.0 ] },
-        { "name": "filledAlpha",  "type": "float",     "count": 1,  "values": [ 0.25 ] }
+        { "name": "filledAlpha",  "type": "float",     "count": 1,  "values": [ 0.25 ] },
+        { "name": "width",        "type": "float",     "count": 1,  "values": [ 1.0 ] }
     ]
 }

--- a/src/main/resources/assets/minecraft/shaders/program/esp_outline.json
+++ b/src/main/resources/assets/minecraft/shaders/program/esp_outline.json
@@ -1,0 +1,21 @@
+{
+    "blend": {
+        "func": "add",
+        "srcrgb": "srcalpha",
+        "dstrgb": "1-srcalpha"
+    },
+    "vertex": "sobel",
+    "fragment": "esp_outline",
+    "attributes": [ "Position" ],
+    "samplers": [
+        { "name": "DiffuseSampler" }
+    ],
+    "uniforms": [
+        { "name": "ProjMat",      "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
+        { "name": "InSize",       "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "OutSize",      "type": "float",     "count": 2,  "values": [ 1.0, 1.0 ] },
+        { "name": "width",        "type": "float",     "count": 1,  "values": [ 1.0 ] },
+        { "name": "outlineAlpha", "type": "float",     "count": 1,  "values": [ 1.0 ] },
+        { "name": "filledAlpha",  "type": "float",     "count": 1,  "values": [ 0.25 ] }
+    ]
+}


### PR DESCRIPTION
**Describe the pull**
1. Added shader esp with options of filled, outline, hiding model, blurred background.

**Describe how this pull is helpful**
1. Better and cooler esp

**Additional context**
1. Too lazy to add Gaussian blur. I just use the minecraft one.
2. #1161 Tried to add that to StorageESP. Failed because the way of how minecraft renders tile entity. So just leave it open.

Example:
![image](https://user-images.githubusercontent.com/62033805/95224535-c5e67300-07c8-11eb-8b2d-6f2f0f0ee31d.png)
