### PR TITLE
[feature] Enchanting Table books option for NoRender

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinNetHandlerPlayClient.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinNetHandlerPlayClient.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 public class MixinNetHandlerPlayClient {
 
     @Inject(method = "handleChunkData",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;read(Lnet/minecraft/network/PacketBuffer;IZ)V"),
+            at = @At(value = "RETURN", target = "Lnet/minecraft/world/chunk/Chunk;read(Lnet/minecraft/network/PacketBuffer;IZ)V"),
             locals = LocalCapture.CAPTURE_FAILHARD)
     private void read(SPacketChunkData data, CallbackInfo info, Chunk chunk) {
         KamiEventBus.INSTANCE.post(new ChunkEvent(chunk, data));

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinTileEntityEnchantmentTableRenderer.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinTileEntityEnchantmentTableRenderer.java
@@ -1,0 +1,18 @@
+package me.zeroeightsix.kami.mixin.client;
+
+import me.zeroeightsix.kami.module.modules.render.NoRender;
+import net.minecraft.client.renderer.tileentity.TileEntityEnchantmentTableRenderer;
+import net.minecraft.tileentity.TileEntityEnchantmentTable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(TileEntityEnchantmentTableRenderer.class)
+public class MixinTileEntityEnchantmentTableRenderer {
+
+    @Inject(method = "render", at = @At("HEAD"), cancellable = true)
+    public void render(TileEntityEnchantmentTable te, double x, double y, double z, float partialTicks, int destroyStage, float alpha, CallbackInfo ci) {
+        if(NoRender.INSTANCE.isEnabled()&&NoRender.INSTANCE.getEnchantingtable().getValue())ci.cancel();
+    }
+}

--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinTileEntityEnchantmentTableRenderer.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinTileEntityEnchantmentTableRenderer.java
@@ -11,8 +11,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(TileEntityEnchantmentTableRenderer.class)
 public class MixinTileEntityEnchantmentTableRenderer {
 
+    @SuppressWarnings("SameParameterValue")
     @Inject(method = "render", at = @At("HEAD"), cancellable = true)
     public void render(TileEntityEnchantmentTable te, double x, double y, double z, float partialTicks, int destroyStage, float alpha, CallbackInfo ci) {
-        if(NoRender.INSTANCE.isEnabled()&&NoRender.INSTANCE.getEnchantingtable().getValue())ci.cancel();
+        if (NoRender.INSTANCE.isEnabled() && NoRender.INSTANCE.getEnchantingTable().getValue()) ci.cancel();
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/NoRender.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/NoRender.kt
@@ -30,9 +30,9 @@ object NoRender : Module() {
     private val explosion = register(Settings.b("Explosions", true))
     val beacon = register(Settings.b("BeaconBeams", false))
     val skylight = register(Settings.b("SkyLightUpdates", true))
-    val particles = register(Settings.b("Particles", false))
-    val enchantingtable = register(Settings.b("Enchantingtable Books", true))
-    val enchantingtableSnow = register(Settings.b("Enchantingtable as Snow", false))
+    private val particles = register(Settings.b("Particles", false))
+    val enchantingTable = register(Settings.b("EnchantingBooks", true))
+    private val enchantingTableSnow = register(Settings.b("EnchantBookSnow", false))
 
     init {
         listener<PacketEvent.Receive> {
@@ -47,16 +47,16 @@ object NoRender : Module() {
         }
 
         listener<ChunkEvent> {
-            if(!enchantingtableSnow.value)return@listener
-            val chunk =it.chunk
-            val layer =Blocks.SNOW_LAYER.defaultState.withProperty(BlockSnow.LAYERS, Integer.valueOf(7))
-            val yRange = IntRange(0, 256)
-            val xRange = IntRange(chunk.x*16, chunk.x*16+15)
-            val zRange = IntRange(chunk.z*16, chunk.z*16+15)
+            if (enchantingTableSnow.value) { // replaces enchanting tables with snow
+                val chunk = it.chunk
+                val layer = Blocks.SNOW_LAYER.defaultState.withProperty(BlockSnow.LAYERS, Integer.valueOf(7))
+                val xRange = IntRange(chunk.x * 16, chunk.x * 16 + 15)
+                val zRange = IntRange(chunk.z * 16, chunk.z * 16 + 15)
 
-            for (y in yRange) for (x in xRange) for (z in zRange) {
-                if (chunk.getBlockState(BlockPos(chunk.x * 16+x, y, chunk.z * 16+z)).block== Blocks.ENCHANTING_TABLE){
-                    chunk.setBlockState(BlockPos(chunk.x * 16+x, y, chunk.z * 16+z),layer )
+                for (y in 0..256) for (x in xRange) for (z in zRange) {
+                    if (chunk.getBlockState(BlockPos(chunk.x * 16 + x, y, chunk.z * 16 + z)).block == Blocks.ENCHANTING_TABLE) {
+                        chunk.setBlockState(BlockPos(chunk.x * 16 + x, y, chunk.z * 16 + z), layer)
+                    }
                 }
             }
         }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/NoRender.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/NoRender.kt
@@ -1,12 +1,16 @@
 package me.zeroeightsix.kami.module.modules.render
 
+import me.zeroeightsix.kami.event.events.ChunkEvent
 import me.zeroeightsix.kami.event.events.PacketEvent
 import me.zeroeightsix.kami.event.events.SafeTickEvent
 import me.zeroeightsix.kami.module.Module
 import me.zeroeightsix.kami.setting.Settings
 import me.zeroeightsix.kami.util.event.listener
+import net.minecraft.block.BlockSnow
 import net.minecraft.entity.item.EntityItem
+import net.minecraft.init.Blocks
 import net.minecraft.network.play.server.*
+import net.minecraft.util.math.BlockPos
 import net.minecraftforge.client.event.RenderBlockOverlayEvent
 
 @Module.Info(
@@ -27,6 +31,8 @@ object NoRender : Module() {
     val beacon = register(Settings.b("BeaconBeams", false))
     val skylight = register(Settings.b("SkyLightUpdates", true))
     val particles = register(Settings.b("Particles", false))
+    val enchantingtable = register(Settings.b("Enchantingtable Books", true))
+    val enchantingtableSnow = register(Settings.b("Enchantingtable as Snow", false))
 
     init {
         listener<PacketEvent.Receive> {
@@ -38,6 +44,21 @@ object NoRender : Module() {
                     it.packet is SPacketExplosion && explosion.value ||
                     it.packet is SPacketSpawnPainting && paint.value ||
                     it.packet is SPacketParticles && particles.value) it.cancel()
+        }
+
+        listener<ChunkEvent> {
+            if(!enchantingtableSnow.value)return@listener
+            val chunk =it.chunk
+            val layer =Blocks.SNOW_LAYER.defaultState.withProperty(BlockSnow.LAYERS, Integer.valueOf(7))
+            val yRange = IntRange(0, 256)
+            val xRange = IntRange(chunk.x*16, chunk.x*16+15)
+            val zRange = IntRange(chunk.z*16, chunk.z*16+15)
+
+            for (y in yRange) for (x in xRange) for (z in zRange) {
+                if (chunk.getBlockState(BlockPos(chunk.x * 16+x, y, chunk.z * 16+z)).block== Blocks.ENCHANTING_TABLE){
+                    chunk.setBlockState(BlockPos(chunk.x * 16+x, y, chunk.z * 16+z),layer )
+                }
+            }
         }
 
         listener<RenderBlockOverlayEvent> {

--- a/src/main/resources/mixins.kami.json
+++ b/src/main/resources/mixins.kami.json
@@ -46,8 +46,8 @@
     "MixinRenderPlayer",
     "MixinStateImplementation",
     "MixinTileEntityBeacon",
+    "MixinTileEntityEnchantmentTableRenderer",
     "MixinVisGraph",
-    "MixinWorld",
-    "MixinTileEntityEnchantmentTableRenderer"
+    "MixinWorld"
   ]
 }

--- a/src/main/resources/mixins.kami.json
+++ b/src/main/resources/mixins.kami.json
@@ -47,6 +47,7 @@
     "MixinStateImplementation",
     "MixinTileEntityBeacon",
     "MixinVisGraph",
-    "MixinWorld"
+    "MixinWorld",
+    "MixinTileEntityEnchantmentTableRenderer"
   ]
 }


### PR DESCRIPTION
I changed the chunk event to be fired after the chunk parsing so you can modify the results.
I then modify the results of the parsed packet to have snowlayers where Enchantingtables would be.
This only changes blocks if the option was active while the chunkpacket came in !!!

I made an option for canceling the rendercall for the book on top of Enchantingtables.
In the future it would be good to make a custom block for possibly every tileentity with the correct hitbox and textures so you can render that when a tileentity would have been rendered.
