### PR TITLE
[fix] Fix Autoreconnect and AntiAfk bug

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
@@ -57,8 +57,8 @@ object AntiAFK : Module() {
 
     override fun onDisable() {
         startPos = null
-        baritoneCancel()
         BaritoneUtils.settings()?.disconnectOnArrival?.value = baritoneDisconnectOnArrival
+        BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
     }
 
     init {
@@ -87,7 +87,7 @@ object AntiAFK : Module() {
 
         listener<SafeTickEvent> {
             if (inputTimeout.value != 0) {
-                if (isBaritoneActive) inputTimer.reset()
+                if (BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.isActive) inputTimer.reset()
                 if (!inputTimer.tick(inputTimeout.value.toLong(), false)) {
                     startPos = null
                     return@listener
@@ -104,7 +104,7 @@ object AntiAFK : Module() {
                     Action.TURN -> mc.player.rotationYaw = Random.nextDouble(-180.0, 180.0).toFloat()
                 }
 
-                if (walk.value && !isBaritoneActive) {
+                if (walk.value && !BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.isActive) {
                     if (startPos == null) startPos = mc.player.position
                     startPos?.let {
                         when (squareStep) {
@@ -150,19 +150,13 @@ object AntiAFK : Module() {
         TURN(turn)
     }
 
-    private val isBaritoneActive: Boolean = if (mc.player != null) BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.isActive else false
-
     private fun baritoneGotoXZ(x: Int, z: Int) {
         BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.setGoalAndPath(GoalXZ(x, z))
     }
 
-    private fun baritoneCancel() {
-        BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
-    }
-
     init {
         walk.settingListener = Setting.SettingListeners {
-            if (isBaritoneActive) BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
+            BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
         }
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
@@ -153,4 +153,12 @@ object AntiAFK : Module() {
     private fun baritoneGotoXZ(x: Int, z: Int) {
         BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.setGoalAndPath(GoalXZ(x, z))
     }
+
+    init {
+        walk.settingListener = Setting.SettingListeners {
+            if (BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.isActive) {
+                BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
+            }
+        }
+    }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
@@ -153,10 +153,4 @@ object AntiAFK : Module() {
     private fun baritoneGotoXZ(x: Int, z: Int) {
         BaritoneAPI.getProvider().primaryBaritone.customGoalProcess.setGoalAndPath(GoalXZ(x, z))
     }
-
-    init {
-        walk.settingListener = Setting.SettingListeners {
-            BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
-        }
-    }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
@@ -51,13 +51,14 @@ object AntiAFK : Module() {
     }
 
     override fun onEnable() {
+        inputTimer.reset()
         baritoneDisconnectOnArrival()
     }
 
     override fun onDisable() {
         startPos = null
-        BaritoneUtils.settings()?.disconnectOnArrival?.value = baritoneDisconnectOnArrival
         baritoneCancel()
+        BaritoneUtils.settings()?.disconnectOnArrival?.value = baritoneDisconnectOnArrival
     }
 
     init {
@@ -156,7 +157,7 @@ object AntiAFK : Module() {
     }
 
     private fun baritoneCancel() {
-        if (walk.value && isBaritoneActive) BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
+        BaritoneAPI.getProvider().primaryBaritone.pathingBehavior.cancelEverything()
     }
 
     init {

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoReconnect.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoReconnect.kt
@@ -44,7 +44,7 @@ object AutoReconnect : Module() {
 
         override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
             super.drawScreen(mouseX, mouseY, partialTicks)
-            val text = "Reconnecting in ${timer.stop()}ms"
+            val text = "Reconnecting in ${delay.value - timer.stop()}ms"
             fontRenderer.drawString(text, width / 2f - fontRenderer.getStringWidth(text) / 2f, height - 32f, 0xffffff, true)
         }
     }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoReconnect.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoReconnect.kt
@@ -16,7 +16,7 @@ import net.minecraft.client.multiplayer.ServerData
         alwaysListening = true
 )
 object AutoReconnect : Module() {
-    private val delay = register(Settings.integerBuilder("Delay").withValue(5000).withRange(100, 10000).withStep(100))
+    private val delay = register(Settings.integerBuilder("Delay").withValue(5000).withRange(100, 100000).withStep(100))
 
     private var prevServerDate: ServerData? = null
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoReconnect.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoReconnect.kt
@@ -16,9 +16,11 @@ import net.minecraft.client.multiplayer.ServerData
         alwaysListening = true
 )
 object AutoReconnect : Module() {
-    private val delay = register(Settings.integerBuilder("Delay").withValue(5000).withRange(100, 100000).withStep(100))
+    private val delay = register(Settings.floatBuilder("Delay").withValue(5.0f).withRange(1.0f, 100.0f).withStep(0.5f))
 
     private var prevServerDate: ServerData? = null
+
+    private var sToMs = 1000.0f
 
     init {
         listener<GuiScreenEvent.Closed> {
@@ -37,14 +39,14 @@ object AutoReconnect : Module() {
         private val timer = TimerUtils.StopTimer()
 
         override fun updateScreen() {
-            if (timer.stop() >= delay.value) {
+            if (timer.stop() >= (delay.value * sToMs)) {
                 mc.displayGuiScreen(GuiConnecting(parentScreen, mc, mc.currentServerData ?: prevServerDate ?: return))
             }
         }
 
         override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
             super.drawScreen(mouseX, mouseY, partialTicks)
-            val text = "Reconnecting in ${delay.value - timer.stop()}ms"
+            val text = "Reconnecting in ${((delay.value * sToMs) - timer.stop()).toInt()}ms"
             fontRenderer.drawString(text, width / 2f - fontRenderer.getStringWidth(text) / 2f, height - 32f, 0xffffff, true)
         }
     }


### PR DESCRIPTION
The following changes were made to fix autoreconnect and antiAFK module bugs:

1. autoreconnect max delay increased to 100s for 2b2t (needs at least 30s max for queue)
2. autoreconnect count down instead of up for reconnect timer message
3. Reset timer when activating antiAFK module
4. Removed a condition from antiAFK module that was preventing baritone from cancelling its path when antiAFK was disabled