### PR TITLE
[fix] Javafx dependency and Travis jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- openjdk8
+- openjdk11
 before_install:
 - chmod +x gradlew
 - "./gradlew setupDecompWorkspace"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: java
-jdk:
-- openjdk11
-before_install:
-- chmod +x gradlew
+jdk: openjdk11
+script: "./gradlew build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ jdk:
 - openjdk11
 before_install:
 - chmod +x gradlew
-- "./gradlew setupDecompWorkspace"

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ plugins {
     id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
-apply plugin: 'org.openjfx.javafxplugin'
 apply plugin: 'kotlin'
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'org.spongepowered.mixin'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,13 @@ buildscript {
     }
 }
 
+plugins {
+    id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
+}
+
+mainClassName = '...'
+
 apply plugin: 'kotlin'
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'org.spongepowered.mixin'
@@ -69,6 +76,11 @@ repositories {
     }
     mavenCentral()
     jcenter()
+}
+
+javafx {
+    version = "11.0.2"
+    modules = [ 'javafx.controls' ]
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,10 @@ buildscript {
 }
 
 plugins {
-    id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
-mainClassName = '...'
-
+apply plugin: 'org.openjfx.javafxplugin'
 apply plugin: 'kotlin'
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'org.spongepowered.mixin'


### PR DESCRIPTION
**Description**
Add javafx to Gradle dependencies so no manual installation is necessary.

**Describe how this pull is helpful**
Its a nightmare to set up manually.

**Ideas for improvements**
This happens on activating Chams module.
<img src="https://cdn.discordapp.com/attachments/744735300554588320/771185936062087178/unknown.png">

Rendering fonts on 4K looks a bit crumbly
<img src="https://cdn.discordapp.com/attachments/744735300554588320/771187145506816010/unknown.png">

HUD is weired
<img src="https://cdn.discordapp.com/attachments/744735300554588320/771187501372014592/unknown.png">

Font of LagNotifier is broken
<img src="https://cdn.discordapp.com/attachments/744735300554588320/771188018857246730/unknown.png">