### PR TITLE
[feature] EatBadFood setting for the AutoEat module

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
@@ -25,6 +25,7 @@ object AutoEat : Module() {
     private val foodLevel = register(Settings.integerBuilder("BelowHunger").withValue(15).withRange(1, 20).withStep(1))
     private val healthLevel = register(Settings.integerBuilder("BelowHealth").withValue(8).withRange(1, 20).withStep(1))
     private val pauseBaritone = register(Settings.b("PauseBaritone", true))
+    private val eatBadFood = register(Settings.b("EatBadFood", false))
 
     private var lastSlot = -1
     var eating = false
@@ -36,12 +37,15 @@ object AutoEat : Module() {
 
     private fun passItemCheck(stack: ItemStack): Boolean {
         val item: Item = stack.getItem()
-        if (item == Items.ROTTEN_FLESH
-                || item == Items.SPIDER_EYE
-                || item == Items.POISONOUS_POTATO
-                || (item == Items.FISH && (stack.metadata == 3 || stack.metadata == 2)) // Pufferfish, Clown fish
-                || item == Items.CHORUS_FRUIT) {
-            return false
+        // The player will not auto eat the food below if the EatBadFood setting is disabled
+        if (eatBadFood.value == false) {
+            if (item == Items.ROTTEN_FLESH
+                    || item == Items.SPIDER_EYE
+                    || item == Items.POISONOUS_POTATO
+                    || (item == Items.FISH && (stack.metadata == 3 || stack.metadata == 2)) // Pufferfish, Clown fish
+                    || item == Items.CHORUS_FRUIT) {
+                return false
+            }
         }
         return true
     }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
@@ -42,7 +42,7 @@ object AutoEat : Module() {
             return false
         }
         // The player will not auto eat the food below if the EatBadFood setting is disabled
-        if (eatBadFood.value == false) {
+        if (!eatBadFood.value) {
             if (item == Items.ROTTEN_FLESH
                     || item == Items.SPIDER_EYE
                     || item == Items.POISONOUS_POTATO

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
@@ -37,20 +37,21 @@ object AutoEat : Module() {
 
     private fun passItemCheck(stack: ItemStack): Boolean {
         val item: Item = stack.getItem()
+
         // Excluded Chorus Fruit since it is mainly used to teleport the player
         if (item == Items.CHORUS_FRUIT) {
             return false
         }
+
         // The player will not auto eat the food below if the EatBadFood setting is disabled
-        if (!eatBadFood.value) {
-            if (item == Items.ROTTEN_FLESH
-                    || item == Items.SPIDER_EYE
-                    || item == Items.POISONOUS_POTATO
-                    || (item == Items.FISH && (stack.metadata == 3 || stack.metadata == 2)) // Pufferfish, Clown fish
-                    || item == Items.CHORUS_FRUIT) {
-                return false
-            }
+        if (!eatBadFood.value && (item == Items.ROTTEN_FLESH
+                        || item == Items.SPIDER_EYE
+                        || item == Items.POISONOUS_POTATO
+                        || (item == Items.FISH && (stack.metadata == 3 || stack.metadata == 2)) // Puffer fish, Clown fish
+                        || item == Items.CHORUS_FRUIT)) {
+            return false
         }
+        // If EatBadFood is enabled, just allow them to eat it
         return true
     }
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/player/AutoEat.kt
@@ -37,6 +37,10 @@ object AutoEat : Module() {
 
     private fun passItemCheck(stack: ItemStack): Boolean {
         val item: Item = stack.getItem()
+        // Excluded Chorus Fruit since it is mainly used to teleport the player
+        if (item == Items.CHORUS_FRUIT) {
+            return false
+        }
         // The player will not auto eat the food below if the EatBadFood setting is disabled
         if (eatBadFood.value == false) {
             if (item == Items.ROTTEN_FLESH


### PR DESCRIPTION
**Describe the pull**
This PR is related to #1293.

**Describe how this pull is helpful**
This feature leaves to the user the possibility to eat bad food or not, when using the AutoEat module.
By default, the module does not eat bad food.
This includes :
- Rotten flesh
- Spider eye
- Poisonous potato
- Pufferfish
- Clown fish


**Additional context**
Removed the chorus fruit as auto-eatable ressource as @l1ving stated in a answer #1293.