### PR TITLE
[fix] Flight crash in singleplayer

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/Flight.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/Flight.kt
@@ -47,6 +47,7 @@ object Flight : Module() {
 
     init {
         listener<PlayerTravelEvent> {
+            if (mc.player == null) return@listener
             when (mode.value) {
                 FlightMode.STATIC -> {
                     mc.player.capabilities.isFlying = false


### PR DESCRIPTION

**Describe the pull**
Entering a singleplayer world with flight enabled causes this crash.
https://hastebin.com/tufariposu.log

**Describe how this pull is helpful**
Fixes minor niche crash.

**Additional context**
Quick and dirty fix, please feel free to propose better solution.