### PR TITLE
Fixed AutoWalk bug

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/AutoWalk.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/AutoWalk.kt
@@ -45,6 +45,7 @@ object AutoWalk : Module() {
     }
 
     override fun onEnable() {
+        if (mode.value != AutoWalkMode.BARITONE) return
         startPathing()
     }
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/movement/AutoWalk.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/movement/AutoWalk.kt
@@ -44,11 +44,6 @@ object AutoWalk : Module() {
         }
     }
 
-    override fun onEnable() {
-        if (mode.value != AutoWalkMode.BARITONE) return
-        startPathing()
-    }
-
     override fun onDisable() {
         if (mc.player != null) BaritoneUtils.cancelEverything()
     }


### PR DESCRIPTION
Baritone would activate regardless of which setting was applied. This bug fixes it (hopefully)

**Describe the pull**
Restores some old code that was removed (accidentally?) in the rewrite

**Describe how this pull is helpful**
Makes AutoWalk forward and backward mode work properly.

**Additional context**
EZ 1-line edit with no testing