### PR TITLE
[enhancement] colorChangeRange should only appear if rangedColor is selected on the Tracers module

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/Tracers.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/Tracers.kt
@@ -46,7 +46,7 @@ object Tracers : Module() {
 
     /* General rendering settings */
     private val rangedColor = register(Settings.booleanBuilder("RangedColor").withValue(true).withVisibility { page.value == Page.RENDERING }.build())
-    private val colorChangeRange = register(Settings.integerBuilder("ColorChangeRange").withValue(16).withRange(1, 128).withVisibility { page.value == Page.RENDERING }.build())
+    private val colorChangeRange = register(Settings.integerBuilder("ColorChangeRange").withValue(16).withRange(1, 128).withVisibility { page.value == Page.RENDERING && rangedColor.value }.build())
     private val playerOnly = register(Settings.booleanBuilder("PlayerOnly").withValue(true).withVisibility { page.value == Page.RENDERING && rangedColor.value }.build())
     private val colorFar = register(Settings.enumBuilder(DyeColors::class.java, "FarColor").withValue(DyeColors.WHITE).withVisibility { page.value == Page.COLOR }.build())
     private val aFar = register(Settings.integerBuilder("FarAlpha").withValue(127).withRange(0, 255).withStep(1).withVisibility { page.value == Page.RENDERING && rangedColor.value }.build())


### PR DESCRIPTION
**Describe the pull**
Very small PR.
Like title says this hides the option named "ColorChangeRange" in the Tracers module if the option named "RangedColor" is not selected, because there is no need for this option to appear if the user did not activate ranged color.

**Describe how this pull is helpful**
I don't know how or why I forgot to add that to #1589 but here it is.

**Additional context**
None.
