### PR TITLE
[cleanup] Minecraft#displayGuiScreen Mixin

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraft.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/MixinMinecraft.java
@@ -5,7 +5,6 @@ import me.zeroeightsix.kami.event.events.GuiScreenEvent;
 import me.zeroeightsix.kami.module.modules.combat.CrystalAura;
 import me.zeroeightsix.kami.module.modules.misc.DiscordRPC;
 import me.zeroeightsix.kami.util.ConfigUtils;
-import me.zeroeightsix.kami.util.Wrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.SoundHandler;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -14,17 +13,15 @@ import net.minecraft.client.multiplayer.PlayerControllerMP;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.settings.GameSettings;
-import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.RayTraceResult;
-import org.lwjgl.input.Keyboard;
-import org.lwjgl.input.Mouse;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
@@ -59,58 +56,13 @@ public class MixinMinecraft {
         }
     }
 
-    @Inject(method = "displayGuiScreen", at = @At("HEAD"), cancellable = true)
-    public void displayGuiScreen(GuiScreen guiScreenIn, CallbackInfo info) {
-        GuiScreenEvent.Closed screenEvent = new GuiScreenEvent.Closed(Wrapper.getMinecraft().currentScreen);
+    @ModifyVariable(method = "displayGuiScreen", at = @At("HEAD"), argsOnly = true)
+    public GuiScreen editDisplayGuiScreen(GuiScreen guiScreenIn) {
+        GuiScreenEvent.Closed screenEvent = new GuiScreenEvent.Closed(this.currentScreen);
         KamiEventBus.INSTANCE.post(screenEvent);
         GuiScreenEvent.Displayed screenEvent1 = new GuiScreenEvent.Displayed(guiScreenIn);
         KamiEventBus.INSTANCE.post(screenEvent1);
-        guiScreenIn = screenEvent1.getScreen();
-
-        if (guiScreenIn == null && this.world == null) {
-            guiScreenIn = new GuiMainMenu();
-        } else if (guiScreenIn == null && this.player.getHealth() <= 0.0F) {
-            guiScreenIn = new GuiGameOver(null);
-        }
-
-        GuiScreen old = this.currentScreen;
-        net.minecraftforge.client.event.GuiOpenEvent event = new net.minecraftforge.client.event.GuiOpenEvent(guiScreenIn);
-
-        if (net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(event)) return;
-
-        guiScreenIn = event.getGui();
-        if (old != null && guiScreenIn != old) {
-            old.onGuiClosed();
-        }
-
-        if (guiScreenIn instanceof GuiMainMenu || guiScreenIn instanceof GuiMultiplayer) {
-            this.gameSettings.showDebugInfo = false;
-            this.ingameGUI.getChatGUI().clearChatMessages(true);
-        }
-
-        this.currentScreen = guiScreenIn;
-
-        if (guiScreenIn != null) {
-            Minecraft.getMinecraft().setIngameNotInFocus();
-            KeyBinding.unPressAllKeys();
-
-            while (Mouse.next()) {
-            }
-
-            while (Keyboard.next()) {
-            }
-
-            ScaledResolution scaledresolution = new ScaledResolution(Minecraft.getMinecraft());
-            int i = scaledresolution.getScaledWidth();
-            int j = scaledresolution.getScaledHeight();
-            guiScreenIn.setWorldAndResolution(Minecraft.getMinecraft(), i, j);
-            this.skipRenderWorld = false;
-        } else {
-            this.soundHandler.resumeSounds();
-            Minecraft.getMinecraft().setIngameFocus();
-        }
-
-        info.cancel();
+        return screenEvent1.getScreen();
     }
 
     @Inject(method = "run", at = @At(value = "INVOKE",


### PR DESCRIPTION
**Describe the pull**
This pull will replace the `@Inject` into `Minecraft#displayGuiScreen` with a simpler `@ModifyVariable`. It also uses `this.currentScreen` instead of `Wrapper.getMinecraft().currentScreen`.

**Describe how this pull is helpful**
The current method for firing events is undesirable. It cancels the entire rest of the method, which makes compatibility with other mods difficult if those mods wish to inject partway through the method. It also copies a lot of code from the original method, which is unnecessary, since it is not modified. This new method will reduce the amount of code needed and improve compatibility.
Also, using the shadowed `this.currentScreen` is more concise than using `Wrapper.getMinecraft()` to basically get itself, and then getting `currentScreen`.

**Additional context**
I need this for compatibility with my own mod.
