### PR TITLE
Added NewChunks to the Radar and improved unloading of NewChunks

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
@@ -3,6 +3,7 @@ package me.zeroeightsix.kami.gui.kami.theme.staticui
 import me.zeroeightsix.kami.gui.kami.component.Radar
 import me.zeroeightsix.kami.gui.rgui.render.AbstractComponentUI
 import me.zeroeightsix.kami.manager.managers.FriendManager
+import me.zeroeightsix.kami.module.modules.render.NewChunks
 import me.zeroeightsix.kami.util.EntityUtils.isCurrentlyNeutral
 import me.zeroeightsix.kami.util.EntityUtils.isPassiveMob
 import me.zeroeightsix.kami.util.Wrapper
@@ -10,6 +11,8 @@ import me.zeroeightsix.kami.util.color.ColorHolder
 import me.zeroeightsix.kami.util.graphics.GlStateUtils
 import me.zeroeightsix.kami.util.graphics.RenderUtils2D.drawCircleFilled
 import me.zeroeightsix.kami.util.graphics.RenderUtils2D.drawCircleOutline
+import me.zeroeightsix.kami.util.graphics.RenderUtils2D.drawRectFilled
+import me.zeroeightsix.kami.util.graphics.RenderUtils2D.drawRectOutline
 import me.zeroeightsix.kami.util.graphics.VertexHelper
 import me.zeroeightsix.kami.util.graphics.font.FontRenderAdapter
 import me.zeroeightsix.kami.util.math.Vec2d
@@ -43,27 +46,57 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         val vertexHelper = VertexHelper(GlStateUtils.useVbo())
         drawCircleFilled(vertexHelper, radius = radius.toDouble(), color = ColorHolder(28, 28, 28, 200))
         drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = ColorHolder(155, 144, 255, 255))
-        drawCircleFilled(vertexHelper, radius = 2.0 / scale, color = ColorHolder(255, 255, 255, 224))
-
         glRotatef(Wrapper.player!!.rotationYaw + 180, 0f, 0f, -1f)
+
+        if (NewChunks.isEnabled && NewChunks.renderMode.value != NewChunks.RenderMode.WORLD) {
+            val playerOffset = Vec2d((Wrapper.player!!.posX - (Wrapper.player!!.chunkCoordX shl 4)), (Wrapper.player!!.posZ - (Wrapper.player!!.chunkCoordZ shl 4)))
+            val chunkDist = (radius * NewChunks.radarScale.value).toInt() shr 4
+            for (chunkX in -chunkDist..chunkDist) {
+                for (chunkZ in -chunkDist..chunkDist) {
+                    val pos0 = getChunkPos(chunkX, chunkZ, playerOffset)
+                    val pos1 = getChunkPos(chunkX + 1, chunkZ + 1, playerOffset)
+
+                    if (squareInRadius(pos0, pos1)) {
+                        val chunk = Wrapper.world!!.getChunk(Wrapper.player!!.chunkCoordX + chunkX, Wrapper.player!!.chunkCoordZ + chunkZ)
+                        if (!chunk.isLoaded)
+                            drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(100, 100, 100, 100))
+                        drawRectOutline(vertexHelper, pos0, pos1, 0.3f, ColorHolder(255, 0, 0, 100))
+                    }
+                }
+            }
+
+            for (chunk in NewChunks.chunks) {
+
+                val pos0 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX, chunk.z - Wrapper.player!!.chunkCoordZ, playerOffset)
+                val pos1 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX + 1, chunk.z - Wrapper.player!!.chunkCoordZ + 1, playerOffset)
+
+                if (squareInRadius(pos0, pos1)) {
+                    drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(255, 0, 0, 100))
+                }
+            }
+        }
+
         for (entity in Wrapper.world!!.loadedEntityList) {
             if (entity == null || entity.isDead || entity == Wrapper.player) continue
             val dX = entity.posX - Wrapper.player!!.posX
             val dZ = entity.posZ - Wrapper.player!!.posZ
             val distance = sqrt(dX.pow(2) + dZ.pow(2))
-            if (distance > radius * scale || abs(Wrapper.player!!.posY - entity.posY) > 30) continue
+            if (distance > radius * NewChunks.radarScale.value || abs(Wrapper.player!!.posY - entity.posY) > 30) continue
             val color = getColor(entity)
 
-            drawCircleFilled(vertexHelper, Vec2d(dX / scale, dZ / scale), 2.5 / scale, color = color)
+            drawCircleFilled(vertexHelper, Vec2d(dX / NewChunks.radarScale.value, dZ / NewChunks.radarScale.value), 2.5 / NewChunks.radarScale.value, color = color)
         }
 
-        FontRenderAdapter.drawString("\u00A77z+", -FontRenderAdapter.getStringWidth("+z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = false)
+
+        drawCircleFilled(vertexHelper, radius = 1.0, color = ColorHolder(255, 255, 255, 224))
+
+        FontRenderAdapter.drawString("\u00A77z+", -FontRenderAdapter.getStringWidth("+z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
         glRotatef(90f, 0f, 0f, 1f)
-        FontRenderAdapter.drawString("\u00A77x-", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = false)
+        FontRenderAdapter.drawString("\u00A77x-", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
         glRotatef(90f, 0f, 0f, 1f)
-        FontRenderAdapter.drawString("\u00A77z-", -FontRenderAdapter.getStringWidth("-z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = false)
+        FontRenderAdapter.drawString("\u00A77z-", -FontRenderAdapter.getStringWidth("-z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
         glRotatef(90f, 0f, 0f, 1f)
-        FontRenderAdapter.drawString("\u00A77x+", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = false)
+        FontRenderAdapter.drawString("\u00A77x+", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
 
         glPopMatrix()
     }
@@ -78,8 +111,28 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         }
     }
 
+    //p2.x > p1.x and p2.y > p1.y is assumed
+    private fun squareInRadius(p1: Vec2d, p2: Vec2d): Boolean {
+        return if ((p1.x + p2.x) / 2 > 0) {
+            if ((p1.y + p2.y) / 2 > 0) {
+                p2.length()
+            } else {
+                Vec2d(p2.x, p1.y).length()
+            }
+        } else {
+            if ((p1.y + p2.y) / 2 > 0) {
+                Vec2d(p1.x, p2.y).length()
+            } else {
+                p1.length()
+            }
+        } < radius
+    }
+
+    private fun getChunkPos(x: Int, z: Int, playerOffset: Vec2d): Vec2d {
+        return Vec2d((x shl 4).toDouble(), (z shl 4).toDouble()).subtract(playerOffset).divide(NewChunks.radarScale.value)
+    }
+
     companion object {
-        const val scale = 2.0
         const val radius = 45.0f
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
@@ -48,33 +48,8 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = ColorHolder(155, 144, 255, 255))
         glRotatef(Wrapper.player!!.rotationYaw + 180, 0f, 0f, -1f)
 
-        if (NewChunks.isEnabled && NewChunks.renderMode.value != NewChunks.RenderMode.WORLD) {
-            val playerOffset = Vec2d((Wrapper.player!!.posX - (Wrapper.player!!.chunkCoordX shl 4)), (Wrapper.player!!.posZ - (Wrapper.player!!.chunkCoordZ shl 4)))
-            val chunkDist = (radius * NewChunks.radarScale.value).toInt() shr 4
-            for (chunkX in -chunkDist..chunkDist) {
-                for (chunkZ in -chunkDist..chunkDist) {
-                    val pos0 = getChunkPos(chunkX, chunkZ, playerOffset)
-                    val pos1 = getChunkPos(chunkX + 1, chunkZ + 1, playerOffset)
-
-                    if (squareInRadius(pos0, pos1)) {
-                        val chunk = Wrapper.world!!.getChunk(Wrapper.player!!.chunkCoordX + chunkX, Wrapper.player!!.chunkCoordZ + chunkZ)
-                        if (!chunk.isLoaded)
-                            drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(100, 100, 100, 100))
-                        drawRectOutline(vertexHelper, pos0, pos1, 0.3f, ColorHolder(255, 0, 0, 100))
-                    }
-                }
-            }
-
-            for (chunk in NewChunks.chunks) {
-
-                val pos0 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX, chunk.z - Wrapper.player!!.chunkCoordZ, playerOffset)
-                val pos1 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX + 1, chunk.z - Wrapper.player!!.chunkCoordZ + 1, playerOffset)
-
-                if (squareInRadius(pos0, pos1)) {
-                    drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(255, 0, 0, 100))
-                }
-            }
-        }
+        if (NewChunks.isEnabled && NewChunks.renderMode.value != NewChunks.RenderMode.WORLD)
+            renderNewChunks(vertexHelper)
 
         for (entity in Wrapper.world!!.loadedEntityList) {
             if (entity == null || entity.isDead || entity == Wrapper.player) continue
@@ -87,7 +62,6 @@ class RadarUI : AbstractComponentUI<Radar?>() {
             drawCircleFilled(vertexHelper, Vec2d(dX / NewChunks.radarScale.value, dZ / NewChunks.radarScale.value), 2.5 / NewChunks.radarScale.value, color = color)
         }
 
-
         drawCircleFilled(vertexHelper, radius = 1.0, color = ColorHolder(255, 255, 255, 224))
 
         FontRenderAdapter.drawString("\u00A77z+", -FontRenderAdapter.getStringWidth("+z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
@@ -99,6 +73,34 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         FontRenderAdapter.drawString("\u00A77x+", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
 
         glPopMatrix()
+    }
+
+    private fun renderNewChunks(vertexHelper: VertexHelper){
+        val playerOffset = Vec2d((Wrapper.player!!.posX - (Wrapper.player!!.chunkCoordX shl 4)), (Wrapper.player!!.posZ - (Wrapper.player!!.chunkCoordZ shl 4)))
+        val chunkDist = (radius * NewChunks.radarScale.value).toInt() shr 4
+        for (chunkX in -chunkDist..chunkDist) {
+            for (chunkZ in -chunkDist..chunkDist) {
+                val pos0 = getChunkPos(chunkX, chunkZ, playerOffset)
+                val pos1 = getChunkPos(chunkX + 1, chunkZ + 1, playerOffset)
+
+                if (squareInRadius(pos0, pos1)) {
+                    val chunk = Wrapper.world!!.getChunk(Wrapper.player!!.chunkCoordX + chunkX, Wrapper.player!!.chunkCoordZ + chunkZ)
+                    if (!chunk.isLoaded)
+                        drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(100, 100, 100, 100))
+                    drawRectOutline(vertexHelper, pos0, pos1, 0.3f, ColorHolder(255, 0, 0, 100))
+                }
+            }
+        }
+
+        for (chunk in NewChunks.chunks) {
+
+            val pos0 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX, chunk.z - Wrapper.player!!.chunkCoordZ, playerOffset)
+            val pos1 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX + 1, chunk.z - Wrapper.player!!.chunkCoordZ + 1, playerOffset)
+
+            if (squareInRadius(pos0, pos1)) {
+                drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(255, 0, 0, 100))
+            }
+        }
     }
 
     private fun getColor(entity: Entity): ColorHolder {

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
@@ -55,7 +55,7 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = outlineCircleColor)
         glRotatef(Wrapper.player!!.rotationYaw + 180, 0f, 0f, -1f)
 
-        if (NewChunks.renderRadar) renderNewChunks(vertexHelper)
+        if (NewChunks.isEnabled && NewChunks.isRadarMode) renderNewChunks(vertexHelper)
 
         for (entity in Wrapper.world!!.loadedEntityList) {
             if (entity == null || entity.isDead || entity == Wrapper.player) continue

--- a/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
+++ b/src/main/java/me/zeroeightsix/kami/gui/kami/theme/staticui/RadarUI.kt
@@ -27,6 +27,13 @@ import kotlin.math.sqrt
  * Created by 086 on 11/08/2017.
  */
 class RadarUI : AbstractComponentUI<Radar?>() {
+    private val filledCircleColor = ColorHolder(28, 28, 28, 200)
+    private val outlineCircleColor = ColorHolder(155, 144, 255, 255)
+    private val filledCircleColorDarker = ColorHolder(255, 255, 255, 224)
+    private val rectFilledColor = ColorHolder(100, 100, 100, 100)
+    private val rectOutlineColor = ColorHolder(255, 0, 0, 100)
+    private val rectFilledColorOther = ColorHolder(255, 0, 0, 100)
+    private val radius = 45.0f
 
     override fun handleSizeComponent(component: Radar?) {
         component!!
@@ -44,12 +51,11 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         glTranslated(component.width / 2.0, component.height / 2.0, 0.0)
 
         val vertexHelper = VertexHelper(GlStateUtils.useVbo())
-        drawCircleFilled(vertexHelper, radius = radius.toDouble(), color = ColorHolder(28, 28, 28, 200))
-        drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = ColorHolder(155, 144, 255, 255))
+        drawCircleFilled(vertexHelper, radius = radius.toDouble(), color = filledCircleColor)
+        drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = outlineCircleColor)
         glRotatef(Wrapper.player!!.rotationYaw + 180, 0f, 0f, -1f)
 
-        if (NewChunks.isEnabled && NewChunks.renderMode.value != NewChunks.RenderMode.WORLD)
-            renderNewChunks(vertexHelper)
+        if (NewChunks.renderRadar) renderNewChunks(vertexHelper)
 
         for (entity in Wrapper.world!!.loadedEntityList) {
             if (entity == null || entity.isDead || entity == Wrapper.player) continue
@@ -62,7 +68,7 @@ class RadarUI : AbstractComponentUI<Radar?>() {
             drawCircleFilled(vertexHelper, Vec2d(dX / NewChunks.radarScale.value, dZ / NewChunks.radarScale.value), 2.5 / NewChunks.radarScale.value, color = color)
         }
 
-        drawCircleFilled(vertexHelper, radius = 1.0, color = ColorHolder(255, 255, 255, 224))
+        drawCircleFilled(vertexHelper, radius = 1.0, color = filledCircleColorDarker)
 
         FontRenderAdapter.drawString("\u00A77z+", -FontRenderAdapter.getStringWidth("+z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true)
         glRotatef(90f, 0f, 0f, 1f)
@@ -75,7 +81,7 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         glPopMatrix()
     }
 
-    private fun renderNewChunks(vertexHelper: VertexHelper){
+    private fun renderNewChunks(vertexHelper: VertexHelper) {
         val playerOffset = Vec2d((Wrapper.player!!.posX - (Wrapper.player!!.chunkCoordX shl 4)), (Wrapper.player!!.posZ - (Wrapper.player!!.chunkCoordZ shl 4)))
         val chunkDist = (radius * NewChunks.radarScale.value).toInt() shr 4
         for (chunkX in -chunkDist..chunkDist) {
@@ -86,8 +92,8 @@ class RadarUI : AbstractComponentUI<Radar?>() {
                 if (squareInRadius(pos0, pos1)) {
                     val chunk = Wrapper.world!!.getChunk(Wrapper.player!!.chunkCoordX + chunkX, Wrapper.player!!.chunkCoordZ + chunkZ)
                     if (!chunk.isLoaded)
-                        drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(100, 100, 100, 100))
-                    drawRectOutline(vertexHelper, pos0, pos1, 0.3f, ColorHolder(255, 0, 0, 100))
+                        drawRectFilled(vertexHelper, pos0, pos1, rectFilledColor)
+                    drawRectOutline(vertexHelper, pos0, pos1, 0.3f, rectOutlineColor)
                 }
             }
         }
@@ -98,7 +104,7 @@ class RadarUI : AbstractComponentUI<Radar?>() {
             val pos1 = getChunkPos(chunk.x - Wrapper.player!!.chunkCoordX + 1, chunk.z - Wrapper.player!!.chunkCoordZ + 1, playerOffset)
 
             if (squareInRadius(pos0, pos1)) {
-                drawRectFilled(vertexHelper, pos0, pos1, ColorHolder(255, 0, 0, 100))
+                drawRectFilled(vertexHelper, pos0, pos1, rectFilledColorOther)
             }
         }
     }
@@ -113,7 +119,7 @@ class RadarUI : AbstractComponentUI<Radar?>() {
         }
     }
 
-    //p2.x > p1.x and p2.y > p1.y is assumed
+    // p2.x > p1.x and p2.y > p1.y is assumed
     private fun squareInRadius(p1: Vec2d, p2: Vec2d): Boolean {
         return if ((p1.x + p2.x) / 2 > 0) {
             if ((p1.y + p2.y) / 2 > 0) {
@@ -132,9 +138,5 @@ class RadarUI : AbstractComponentUI<Radar?>() {
 
     private fun getChunkPos(x: Int, z: Int, playerOffset: Vec2d): Vec2d {
         return Vec2d((x shl 4).toDouble(), (z shl 4).toDouble()).subtract(playerOffset).divide(NewChunks.radarScale.value)
-    }
-
-    companion object {
-        const val radius = 45.0f
     }
 }

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/NewChunks.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/NewChunks.kt
@@ -40,7 +40,7 @@ object NewChunks : Module() {
     private val saveInRegionFolder = register(Settings.booleanBuilder("InRegion").withValue(false).withVisibility { saveNewChunks.value })
     private val alsoSaveNormalCoords = register(Settings.booleanBuilder("SaveNormalCoords").withValue(false).withVisibility { saveNewChunks.value })
     private val closeFile = register(Settings.booleanBuilder("CloseFile").withValue(false).withVisibility { saveNewChunks.value })
-    val renderMode = register(Settings.enumBuilder(RenderMode::class.java, "RenderMode").withValue(RenderMode.BOTH))
+    val renderMode = register(Settings.e<RenderMode>("RenderMode", RenderMode.BOTH))
     private val yOffset = register(Settings.integerBuilder("YOffset").withValue(0).withRange(-256, 256).withStep(4).withVisibility { renderMode.value != RenderMode.RADAR })
     private val customColor = register(Settings.booleanBuilder("CustomColor").withValue(false).withVisibility { renderMode.value != RenderMode.RADAR })
     private val red = register(Settings.integerBuilder("Red").withRange(0, 255).withValue(255).withStep(1).withVisibility { customColor.value && renderMode.value != RenderMode.RADAR })
@@ -48,7 +48,7 @@ object NewChunks : Module() {
     private val blue = register(Settings.integerBuilder("Blue").withRange(0, 255).withValue(255).withStep(1).withVisibility { customColor.value && renderMode.value != RenderMode.RADAR })
     private val range = register(Settings.integerBuilder("RenderRange").withValue(256).withRange(64, 1024).withStep(64))
     val radarScale = register(Settings.doubleBuilder("RadarScale").withRange(1.0,10.0).withValue(4.0).withStep(0.1).withVisibility { renderMode.value != RenderMode.WORLD })
-    private val removeMode = register(Settings.enumBuilder(RemoveMode::class.java, "RemoveMode").withValue(RemoveMode.MAX_NUM))
+    private val removeMode = register(Settings.e<RemoveMode>("RemoveMode", RemoveMode.MAX_NUM))
     private val maxNum = register(Settings.integerBuilder("MaxNum").withRange(1000, 100_000).withValue(10_000).withStep(1000).withVisibility { removeMode.value == RemoveMode.MAX_NUM })
 
     private var lastSetting = LastSetting()

--- a/src/main/java/me/zeroeightsix/kami/module/modules/render/NewChunks.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/render/NewChunks.kt
@@ -40,14 +40,14 @@ object NewChunks : Module() {
     private val saveInRegionFolder = register(Settings.booleanBuilder("InRegion").withValue(false).withVisibility { saveNewChunks.value })
     private val alsoSaveNormalCoords = register(Settings.booleanBuilder("SaveNormalCoords").withValue(false).withVisibility { saveNewChunks.value })
     private val closeFile = register(Settings.booleanBuilder("CloseFile").withValue(false).withVisibility { saveNewChunks.value })
-    val renderMode = register(Settings.e<RenderMode>("RenderMode", RenderMode.BOTH))
+    private val renderMode = register(Settings.e<RenderMode>("RenderMode", RenderMode.BOTH))
     private val yOffset = register(Settings.integerBuilder("YOffset").withValue(0).withRange(-256, 256).withStep(4).withVisibility { renderMode.value != RenderMode.RADAR })
     private val customColor = register(Settings.booleanBuilder("CustomColor").withValue(false).withVisibility { renderMode.value != RenderMode.RADAR })
     private val red = register(Settings.integerBuilder("Red").withRange(0, 255).withValue(255).withStep(1).withVisibility { customColor.value && renderMode.value != RenderMode.RADAR })
     private val green = register(Settings.integerBuilder("Green").withRange(0, 255).withValue(255).withStep(1).withVisibility { customColor.value && renderMode.value != RenderMode.RADAR })
     private val blue = register(Settings.integerBuilder("Blue").withRange(0, 255).withValue(255).withStep(1).withVisibility { customColor.value && renderMode.value != RenderMode.RADAR })
     private val range = register(Settings.integerBuilder("RenderRange").withValue(256).withRange(64, 1024).withStep(64))
-    val radarScale = register(Settings.doubleBuilder("RadarScale").withRange(1.0,10.0).withValue(4.0).withStep(0.1).withVisibility { renderMode.value != RenderMode.WORLD })
+    val radarScale = register(Settings.doubleBuilder("RadarScale").withRange(1.0, 10.0).withValue(2.0).withStep(0.1).withVisibility { renderMode.value != RenderMode.WORLD })
     private val removeMode = register(Settings.e<RemoveMode>("RemoveMode", RemoveMode.MAX_NUM))
     private val maxNum = register(Settings.integerBuilder("MaxNum").withRange(1000, 100_000).withValue(10_000).withStep(1000).withVisibility { removeMode.value == RemoveMode.MAX_NUM })
 
@@ -75,7 +75,7 @@ object NewChunks : Module() {
         }
 
         listener<RenderWorldEvent> {
-            if(renderMode.value == RenderMode.RADAR) return@listener
+            if (renderMode.value == RenderMode.RADAR) return@listener
             val y = yOffset.value.toDouble() + if (relative.value) getInterpolatedPos(mc.player, KamiTessellator.pTicks()).y else 0.0
             glLineWidth(2.0f)
             GlStateUtils.depth(false)
@@ -280,9 +280,12 @@ object NewChunks : Module() {
     private enum class RemoveMode {
         UNLOAD, MAX_NUM, NEVER
     }
+
     enum class RenderMode {
         WORLD, RADAR, BOTH
     }
+
+    val renderRadar get() = isActive() && (renderMode.value == RenderMode.BOTH || renderMode.value == RenderMode.RADAR)
 
     private class LastSetting {
         var lastSaveOption: SaveOption? = null


### PR DESCRIPTION
This pull request adds the NewChunks (previously only directly rendered) to the radar. This can give a better overview over the surrounding area than rendering it in the world.
The following settings are added in NewChunks: 

- renderMode: lets you select to render new chunks in the world, radar or both
- radarScale: Scale of the radar is now configurable, to allow using it both for mobs and for new chunks (maybe this should be moved to a dedicated radar menu, when one is added)
- removeMode: Allows to switch how chunks are removed. Either chunk unload, Max number or never
- maxNum: When removeMode is maxnumber and this number is reached the chunks with the greatest distance to the player are deleted first

In the NewChunks module I noticed that chunks are added multiple time, so I changed the type of the collection storing the Chunks to HashSet. There still are a few chunks, which get added multiple times as different instances.