### PR TITLE
Fix not unpausing even though control is lost

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/util/BaritoneUtils.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/BaritoneUtils.kt
@@ -15,14 +15,12 @@ object BaritoneUtils {
     val isPathing get() = primary?.pathingBehavior?.isPathing ?: false
     val isActive
         get() = primary?.customGoalProcess?.isActive ?: false
-            || primary?.pathingControlManager?.mostRecentInControl()?.let {
-            it.isPresent && it.get().isActive
-        } ?: false
+            || primary?.pathingControlManager?.mostRecentInControl()?.orElse(null)?.isActive ?: false
 
     fun pause() {
         if (!paused) {
-            primary?.pathingControlManager?.registerProcess(TemporaryPauseProcess)
             paused = true
+            primary?.pathingControlManager?.registerProcess(TemporaryPauseProcess)
         }
     }
 

--- a/src/main/java/me/zeroeightsix/kami/util/BaritoneUtils.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/BaritoneUtils.kt
@@ -28,9 +28,9 @@ object BaritoneUtils {
 
     fun unpause() {
         if (paused) {
+            paused = false
             primary?.pathingControlManager?.mostRecentInControl()?.let {
                 if (it.isPresent && it.get() == TemporaryPauseProcess) /* Don't run if not paused lol */ {
-                    paused = false
                     it.get().onLostControl()
                 }
             }

--- a/src/main/java/me/zeroeightsix/kami/util/BaritoneUtils.kt
+++ b/src/main/java/me/zeroeightsix/kami/util/BaritoneUtils.kt
@@ -27,14 +27,7 @@ object BaritoneUtils {
     }
 
     fun unpause() {
-        if (paused) {
-            paused = false
-            primary?.pathingControlManager?.mostRecentInControl()?.let {
-                if (it.isPresent && it.get() == TemporaryPauseProcess) /* Don't run if not paused lol */ {
-                    it.get().onLostControl()
-                }
-            }
-        }
+        paused = false
     }
 
     fun cancelEverything() = primary?.pathingBehavior?.cancelEverything()


### PR DESCRIPTION
Sometimes, we call unpause() even though the temporary process lost
control. We should still change the paused variable to false if it is
paused regardless.
