### PR TITLE
[enhancement] Holding "LMENU" aka Alt can now use a separate step value

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AntiAFK.kt
@@ -37,7 +37,7 @@ internal object AntiAFK : Module(
     private val jump = setting("Jump", true)
     private val turn = setting("Turn", true)
     private val walk = setting("Walk", true)
-    private val radius by setting("Radius", 64, 8..128, 8)
+    private val radius by setting("Radius", 64, 8..128, 8, fineStep = 1)
     private val inputTimeout by setting("InputTimeout(m)", 0, 0..15, 1)
     private val allowBreak by setting("AllowBreakingBlocks", false, { walk.value })
 

--- a/src/main/java/me/zeroeightsix/kami/setting/settings/SettingRegister.kt
+++ b/src/main/java/me/zeroeightsix/kami/setting/settings/SettingRegister.kt
@@ -26,8 +26,9 @@ interface SettingRegister<T : Any> {
         step: Int,
         visibility: () -> Boolean = { true },
         consumer: (prev: Int, input: Int) -> Int = { _, input -> input },
-        description: String = ""
-    ) = setting(IntegerSetting(name, value, range, step, visibility, consumer, description))
+        description: String = "",
+        fineStep: Int = step,
+    ) = setting(IntegerSetting(name, value, range, step, visibility, consumer, description, fineStep))
 
     /** Double Setting */
     fun T.setting(
@@ -37,8 +38,9 @@ interface SettingRegister<T : Any> {
         step: Double,
         visibility: () -> Boolean = { true },
         consumer: (prev: Double, input: Double) -> Double = { _, input -> input },
-        description: String = ""
-    ) = setting(DoubleSetting(name, value, range, step, visibility, consumer, description))
+        description: String = "",
+        fineStep: Double = step,
+    ) = setting(DoubleSetting(name, value, range, step, visibility, consumer, description, fineStep))
 
     /** Float Setting */
     fun T.setting(
@@ -48,8 +50,9 @@ interface SettingRegister<T : Any> {
         step: Float,
         visibility: () -> Boolean = { true },
         consumer: (prev: Float, input: Float) -> Float = { _, input -> input },
-        description: String = ""
-    ) = setting(FloatSetting(name, value, range, step, visibility, consumer, description))
+        description: String = "",
+        fineStep: Float = step,
+    ) = setting(FloatSetting(name, value, range, step, visibility, consumer, description, fineStep))
 
     /** Bind Setting */
     fun T.setting(

--- a/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/DoubleSetting.kt
+++ b/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/DoubleSetting.kt
@@ -9,8 +9,9 @@ class DoubleSetting(
     step: Double,
     visibility: () -> Boolean = { true },
     consumer: (prev: Double, input: Double) -> Double = { _, input -> input },
-    description: String = ""
-) : NumberSetting<Double>(name, value, range, step, visibility, consumer, description) {
+    description: String = "",
+    fineStep: Double = step
+) : NumberSetting<Double>(name, value, range, step, visibility, consumer, description, fineStep) {
 
     init {
         consumers.add(0) { _, it ->

--- a/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/FloatSetting.kt
+++ b/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/FloatSetting.kt
@@ -9,8 +9,9 @@ class FloatSetting(
     step: Float,
     visibility: () -> Boolean = { true },
     consumer: (prev: Float, input: Float) -> Float = { _, input -> input },
-    description: String = ""
-) : NumberSetting<Float>(name, value, range, step, visibility, consumer, description) {
+    description: String = "",
+    fineStep: Float = step
+) : NumberSetting<Float>(name, value, range, step, visibility, consumer, description, fineStep) {
 
     init {
         consumers.add(0) { _, it ->

--- a/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/IntegerSetting.kt
+++ b/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/IntegerSetting.kt
@@ -9,8 +9,9 @@ class IntegerSetting(
     step: Int,
     visibility: () -> Boolean = { true },
     consumer: (prev: Int, input: Int) -> Int = { _, input -> input },
-    description: String = ""
-) : NumberSetting<Int>(name, value, range, step, visibility, consumer, description) {
+    description: String = "",
+    fineStep: Int = step
+) : NumberSetting<Int>(name, value, range, step, visibility, consumer, description, fineStep) {
 
     init {
         consumers.add(0) { _, it ->

--- a/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/NumberSetting.kt
+++ b/src/main/java/me/zeroeightsix/kami/setting/settings/impl/number/NumberSetting.kt
@@ -10,7 +10,8 @@ abstract class NumberSetting<T>(
     val step: T,
     visibility: () -> Boolean,
     consumer: (prev: T, input: T) -> T,
-    description: String = ""
+    description: String = "",
+    val fineStep: T
 ) : MutableSetting<T>(name, value, visibility, consumer, description)
     where T : Number, T : Comparable<T> {
 


### PR DESCRIPTION
**Describe the pull**
Currently, this does cause a bit of a UX problem where the number jumps around if ALT is released and then the mouse moves.

Another possibility would be to check for ALT when the drag starts and switch step values then.

A clear and concise description of what the pull is for.

**Describe how this pull is helpful**
Improves the lives of the users when the step value is too large and they want to fine tune some settings

**Additional context**
Scott#6969 ran into this for the AntiAFK module, which is why AntiAFK has it first.