### PR TITLE
[fix] AutoMend should only try to mend when near blocks

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/AutoMend.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/AutoMend.kt
@@ -10,11 +10,10 @@ import me.zeroeightsix.kami.util.items.swapToSlot
 import me.zeroeightsix.kami.util.text.MessageSendHelper
 import me.zeroeightsix.kami.util.threads.runSafe
 import me.zeroeightsix.kami.util.threads.safeListener
-import net.minecraft.enchantment.Enchantment
+import net.minecraft.enchantment.EnchantmentHelper
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.init.Enchantments
 import net.minecraft.init.Items
-import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.network.play.client.CPacketPlayer
 import net.minecraft.util.EnumHand
 import net.minecraft.util.math.RayTraceResult
@@ -114,15 +113,9 @@ internal object AutoMend : Module(
         return slot
     }
 
-    private const val COMPOUND_BYTE_ID: Byte = 10
-    private val MENDING_ID by lazy { Enchantment.getEnchantmentID(Enchantments.MENDING) }
     private fun SafeClientEvent.shouldMend(i: Int): Boolean { // (100 * damage / max damage) >= (100 - 70)
         val stack = player.inventory.armorInventory[i]
-        val hasMending = stack.enchantmentTagList.filter { it.id == COMPOUND_BYTE_ID }.map { it as NBTTagCompound }
-            .any {
-                val id = it.getShort("id").toInt()
-                return@any MENDING_ID == id
-            }
+        val hasMending = EnchantmentHelper.getEnchantmentLevel(Enchantments.MENDING, stack) > 0
         return hasMending && stack.isItemDamaged && 100 * stack.itemDamage / stack.maxDamage > reverseNumber(threshold, 1, 100)
     }
 

--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/AutoMend.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/AutoMend.kt
@@ -102,15 +102,11 @@ internal object AutoMend : Module(
                     }
                     player.inventory.currentItem = xpSlot
                 }
-                if (autoThrow
-                    && throwDelayTimer.tick(throwDelay.value.toLong(), false)
-                    && player.heldItemMainhand.item === Items.EXPERIENCE_BOTTLE) {
-                    if (needsRotationPacket()) {
-                        val packet = PlayerPacket(rotating = true, rotation = Vec2f(player.rotationYaw, 90.0f))
-                        PlayerPacketManager.addPacket(AutoMend, packet)
-                    } else {
+                if (autoThrow && player.heldItemMainhand.item === Items.EXPERIENCE_BOTTLE) {
+                    val packet = PlayerPacket(rotating = true, rotation = Vec2f(player.rotationYaw, 90.0f))
+                    PlayerPacketManager.addPacket(AutoMend, packet)
+                    if (validServerSideRotation() && throwDelayTimer.tick(throwDelay.value.toLong())) {
                         playerController.processRightClick(player, world, EnumHand.MAIN_HAND)
-                        throwDelayTimer.reset() // manually reset after every throw only
                     }
                 }
             }
@@ -156,9 +152,9 @@ internal object AutoMend : Module(
         return false
     }
 
-    private fun needsRotationPacket(): Boolean {
+    private fun validServerSideRotation(): Boolean {
         val pitch = PlayerPacketManager.serverSideRotation.y
-        return pitch !in 80.0f..90.0f
+        return pitch in 80.0f..90.0f
     }
 
     private fun SafeClientEvent.hasBlockUnder(): Boolean {


### PR DESCRIPTION
AutoMend will just YEET XP Bottles even when you are not near the ground.

Additionally, fix up the "shouldMend" when an Item has Mending. Most Anarchy servers always have mending, but we should check for it to avoid wasting bottles.

Additionally, additionally, throw down by sending a rotation packet downward right before we throw, we might want to take velocity into account to throw slightly ahead to give the bottle time to hit the ground.
