### PR TITLE
[fix] Disable enableInHole by default in surround

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/combat/Surround.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/combat/Surround.kt
@@ -36,7 +36,7 @@ internal object Surround : Module(
     private val placeSpeed = setting("PlacesPerTick", 4f, 0.25f..5f, 0.25f)
     private val autoDisable = setting("AutoDisable", AutoDisableMode.OUT_OF_HOLE)
     private val outOfHoleTimeout = setting("OutOfHoleTimeout(t)", 10, 1..50, 5, { autoDisable.value == AutoDisableMode.OUT_OF_HOLE })
-    private val enableInHole = setting("EnableInHole", true)
+    private val enableInHole = setting("EnableInHole", false)
     private val inHoleTimeout = setting("InHoleTimeout(t)", 50, 1..100, 5, { enableInHole.value })
     private val disableStrafe = setting("DisableStrafe", true)
 


### PR DESCRIPTION
I think this was supposed to be fixed in 45735cdd0eed9f8a892fe50515ad9313aee8b4fd

It may surprise some users when surround enables seemingly randomly.