### PR TITLE
[fix] F3 Debug Pie would crash on Single Player

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/mixin/client/player/MixinEntityPlayer.java
+++ b/src/main/java/me/zeroeightsix/kami/mixin/client/player/MixinEntityPlayer.java
@@ -2,6 +2,7 @@ package me.zeroeightsix.kami.mixin.client.player;
 
 import me.zeroeightsix.kami.event.KamiEventBus;
 import me.zeroeightsix.kami.event.events.PlayerTravelEvent;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.MoverType;
 import net.minecraft.entity.player.EntityPlayer;
@@ -9,7 +10,10 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import scala.Console;
 
 @Mixin(value = EntityPlayer.class, priority = Integer.MAX_VALUE)
 public abstract class MixinEntityPlayer extends EntityLivingBase {
@@ -20,11 +24,14 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
 
     @Inject(method = "travel", at = @At("HEAD"), cancellable = true)
     public void travel(float strafe, float vertical, float forward, CallbackInfo info) {
-        PlayerTravelEvent event = new PlayerTravelEvent();
-        KamiEventBus.INSTANCE.post(event);
-        if (event.getCancelled()) {
-            move(MoverType.SELF, motionX, motionY, motionZ);
-            info.cancel();
+        //noinspection ConstantConditions
+        if (EntityPlayerSP.class.isAssignableFrom(this.getClass())) {
+            PlayerTravelEvent event = new PlayerTravelEvent();
+            KamiEventBus.INSTANCE.post(event);
+            if (event.getCancelled()) {
+                move(MoverType.SELF, motionX, motionY, motionZ);
+                info.cancel();
+            }
         }
     }
 }


### PR DESCRIPTION
Possibly would happen on other instances, we will want to test this some before pushing to master/release.

EntityPlayer was sending PlayerTravelEvent, this caused the EventProfiler handler to concurrently modify the Minecraft.profiler instead of the MinecraftServer.profiler.

Additionally, this caused problems when trying to test anything using PlayerTravelEvent as it was getting more than what it should have.
