### PR TITLE
Bumped a few urls to https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
         maven {
             name = 'forge'
-            url = 'http://files.minecraftforge.net/maven'
+            url = 'https://files.minecraftforge.net/maven'
         }
 
         maven {
@@ -59,7 +59,7 @@ repositories {
     }
     maven {
         name = 'swt-repo'
-        url = "http://maven-eclipse.github.io/maven"
+        url = "https://maven-eclipse.github.io/maven"
     }
     maven {
         name = "jitpack.io"


### PR DESCRIPTION
**Describe the pull**
This pull request is pretty straight forward, it replaces `http` urls in the build.gradle with `https`.

**Describe how this pull is helpful**

- Seems like a pretty smart idea to not use http anymore.
- I'm sure you've seen this link, but: https://medium.com/bugbountywriteup/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb

**Additional context**
I made sure that the changes didn't break anything, ran and built the client with no problems.
