### PR TITLE
[feature] AutoOffHand adjustable delay

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/combat/AutoOffhand.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/combat/AutoOffhand.kt
@@ -36,8 +36,10 @@ internal object AutoOffhand : Module(
     category = Category.COMBAT
 ) {
     private val type by setting("Type", Type.TOTEM)
-    private val delay by setting("Delay", 5, 0..20, 1)
-    private val confirmTimeout by setting("Confirm Delay", 4, 0..5, 1)
+    private val delay by setting("Delay", 5, 0..20, 1,
+        description = "Ticks to wait before attempting another move")
+    private val confirmTimeout by setting("Confirm Timeout", 4, 0..5, 1,
+        description = "Ticks to wait to confirm we successfully moved an item into the offhand")
 
     // Totem
     private val hpThreshold by setting("Hp Threshold", 5f, 1f..20f, 0.5f, { type == Type.TOTEM })
@@ -114,8 +116,8 @@ internal object AutoOffhand : Module(
             if (!movingTimer.tick(delay.toLong(), false)) return@safeListener // Delays `delay` ticks
 
             if (!player.inventory.itemStack.isEmpty) { // If player is holding an in inventory
-                if (mc.currentScreen is GuiContainer) {// If inventory is open (playing moving item)
-                    movingTimer.reset() // delay
+                if (mc.currentScreen is GuiContainer) { // If inventory is open (playing moving item)
+                    movingTimer.reset() // reset movingTimer as the user is currently interacting with the inventory.
                 } else { // If inventory is not open (ex. inventory desync)
                     removeHoldingItem()
                 }

--- a/src/main/kotlin/org/kamiblue/client/module/modules/combat/AutoOffhand.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/combat/AutoOffhand.kt
@@ -29,7 +29,6 @@ import org.kamiblue.commons.extension.next
 import org.lwjgl.input.Keyboard
 import kotlin.math.ceil
 import kotlin.math.max
-import kotlin.math.min
 
 internal object AutoOffhand : Module(
     name = "AutoOffhand",

--- a/src/main/kotlin/org/kamiblue/client/module/modules/combat/AutoOffhand.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/combat/AutoOffhand.kt
@@ -37,6 +37,7 @@ internal object AutoOffhand : Module(
 ) {
     private val type by setting("Type", Type.TOTEM)
     private val delay by setting("Delay", 5, 0..20, 1)
+    private val confirmTimeout by setting("Confirm Delay", 4, 0..5, 1)
 
     // Totem
     private val hpThreshold by setting("Hp Threshold", 5f, 1f..20f, 0.5f, { type == Type.TOTEM })
@@ -101,7 +102,7 @@ internal object AutoOffhand : Module(
 
             transactionLog[it.packet.actionNumber] = it.packet.wasAccepted()
             if (!transactionLog.containsValue(false)) {
-                movingTimer.reset(-max(0, delay - 1).toLong()) // If all the click packets were accepted then we reset the timer for next moving
+                movingTimer.reset(-confirmTimeout.toLong()) // If all the click packets were accepted then we reset the timer for next moving
             }
         }
 
@@ -110,11 +111,11 @@ internal object AutoOffhand : Module(
 
             updateDamage()
 
-            if (!movingTimer.tick(delay.toLong(), false)) return@safeListener // Delays 4 ticks by default
+            if (!movingTimer.tick(delay.toLong(), false)) return@safeListener // Delays `delay` ticks
 
             if (!player.inventory.itemStack.isEmpty) { // If player is holding an in inventory
                 if (mc.currentScreen is GuiContainer) {// If inventory is open (playing moving item)
-                    movingTimer.reset() // delay for 5 ticks
+                    movingTimer.reset() // delay
                 } else { // If inventory is not open (ex. inventory desync)
                     removeHoldingItem()
                 }


### PR DESCRIPTION
This allows tuning AutoOffhand to switch faster if the servers allow for it.

The move packet delayed is also tied to this and now runs half a tick faster since I moved the TickTimer to TICK units.