### PR TITLE
[enhancement] Add in Speed modifiers into Strafe

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/util/MovementUtils.kt
+++ b/src/main/kotlin/org/kamiblue/client/util/MovementUtils.kt
@@ -2,6 +2,9 @@ package org.kamiblue.client.util
 
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.Entity
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.init.MobEffects
+import net.minecraft.potion.PotionEffect
 import org.kamiblue.client.event.SafeClientEvent
 import kotlin.math.cos
 import kotlin.math.hypot
@@ -43,5 +46,11 @@ object MovementUtils {
         val yaw = calcMoveYaw()
         player.motionX = -sin(yaw) * speed
         player.motionZ = cos(yaw) * speed
+    }
+
+    fun SafeClientEvent.applySpeedPotionEffects(speed: Double) = if (player.isPotionActive(MobEffects.SPEED)) {
+        speed * (1.0 + 0.2 * (player.getActivePotionEffect(MobEffects.SPEED)!!.amplifier + 1))
+    } else {
+        speed
     }
 }


### PR DESCRIPTION
Only has "NCP/NCP Strict" modes that were lightly tested against NCP.

AAC can be added if there is an AAC server specific speed tweak we need for an anarchy server.

Custom allows tuning manually, but we need more options as other methods are used.

This also gets rid of the "start delay" people have reported and complained about as they state that Future and other clients do not have this problem.

Tested on tree.ac as well as 5b5t and my own testing anarchy server.

We do have some "rubber banding" but it's after a long period of time and appears to be lag compensation related potentially. Still not sure what is exactly happening there, but it only seems to happen once and an while after 1 minute sometimes 45 seconds which seems to long for speed/survivalfly checks. 