### PR TITLE
[feature] Add Radar including NewChunks

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/event/events/RenderRadarEvent.kt
+++ b/src/main/kotlin/org/kamiblue/client/event/events/RenderRadarEvent.kt
@@ -1,0 +1,10 @@
+package org.kamiblue.client.event.events
+
+import org.kamiblue.client.event.Event
+import org.kamiblue.client.util.graphics.VertexHelper
+
+class RenderRadarEvent(
+    val vertexHelper: VertexHelper,
+    val radius: Float,
+    val scale: Float
+) : Event

--- a/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/world/Radar.kt
+++ b/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/world/Radar.kt
@@ -47,7 +47,7 @@ object Radar : HudElement(
         super.renderHud(vertexHelper)
         runSafe {
             drawBorder(vertexHelper)
-            post(RenderRadarEvent(vertexHelper, radius, radarScale)) //Let other modules display radar elements
+            post(RenderRadarEvent(vertexHelper, radius, radarScale)) // Let other modules display radar elements
             drawEntities(vertexHelper)
             drawLabels()
         }
@@ -61,10 +61,10 @@ object Radar : HudElement(
     }
 
     private fun SafeClientEvent.drawEntities(vertexHelper: VertexHelper) {
-        drawCircleFilled(vertexHelper, radius = 1.0, color = primaryColor) //player marker
+        drawCircleFilled(vertexHelper, radius = 1.0, color = primaryColor) // player marker
 
-        val playerTargets = arrayOf(players.value, true, true) //enable friends and sleeping
-        val mobTargets = arrayOf(true, passive.value, neutral.value, hostile.value) //enable mobs
+        val playerTargets = arrayOf(players.value, true, true) // Enable friends and sleeping
+        val mobTargets = arrayOf(true, passive.value, neutral.value, hostile.value) // Enable mobs
         for (entity in EntityUtils.getTargetList(playerTargets, mobTargets, invisible.value, radius * radarScale, ignoreSelf = true)) {
             val entityPosDelta = entity.position.subtract(player.position)
             if (abs(entityPosDelta.y) > 30) continue

--- a/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/world/Radar.kt
+++ b/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/world/Radar.kt
@@ -1,0 +1,146 @@
+package org.kamiblue.client.gui.hudgui.elements.world
+
+import net.minecraft.entity.EntityLivingBase
+import org.kamiblue.client.gui.hudgui.HudElement
+import org.kamiblue.client.manager.managers.FriendManager
+import org.kamiblue.client.module.modules.render.NewChunks
+import org.kamiblue.client.setting.GuiConfig.setting
+import org.kamiblue.client.util.EntityUtils
+import org.kamiblue.client.util.EntityUtils.isNeutral
+import org.kamiblue.client.util.EntityUtils.isPassive
+import org.kamiblue.client.util.color.ColorHolder
+import org.kamiblue.client.util.graphics.RenderUtils2D.drawCircleFilled
+import org.kamiblue.client.util.graphics.RenderUtils2D.drawCircleOutline
+import org.kamiblue.client.util.graphics.RenderUtils2D.drawRectFilled
+import org.kamiblue.client.util.graphics.RenderUtils2D.drawRectOutline
+import org.kamiblue.client.util.graphics.VertexHelper
+import org.kamiblue.client.util.graphics.font.FontRenderAdapter
+import org.kamiblue.client.util.math.Vec2d
+import org.kamiblue.client.util.threads.runSafe
+import org.lwjgl.opengl.GL11.glRotatef
+import org.lwjgl.opengl.GL11.glTranslated
+import kotlin.math.abs
+import kotlin.math.min
+
+object Radar : HudElement(
+    name = "Radar",
+    category = Category.WORLD,
+    description = "Shows entities and new chunks"
+) {
+
+    private val radarScale by setting("Radar scale", 3f, 1f..10f, 0.1f)
+
+    /* Entity type settings */
+    private val players = setting("Players", true)
+    private val passive = setting("Passive Mobs", false)
+    private val neutral = setting("Neutral Mobs", true)
+    private val hostile = setting("Hostile Mobs", true)
+    private val invisible = setting("Invisible Entities", true)
+
+    private val backgroundColor by setting("Background color", ColorHolder(28, 28, 28, 200), true)
+    private val chunkGridColor by setting("Chunk grid color", ColorHolder(255, 0, 0, 100), true)
+    private val distantChunkColor by setting("Distant chunk color", ColorHolder(100, 100, 100, 100), true, description = "Chunks that are not in render distance")
+    private val newChunkColor by setting("New chunk color", ColorHolder(255, 0, 0, 100), true)
+
+    override val hudWidth: Float = 130.0f
+    override val hudHeight: Float = 130.0f
+
+    private val radius get() = min(hudWidth, hudHeight) / 2
+
+    override fun renderHud(vertexHelper: VertexHelper) {
+        super.renderHud(vertexHelper)
+        runSafe {
+            drawBorder(vertexHelper)
+            if (NewChunks.isEnabled && NewChunks.renderMode.value != NewChunks.RenderMode.WORLD) drawNewChunks(vertexHelper)
+            drawEntities(vertexHelper)
+            drawLabels()
+        }
+    }
+
+    private fun drawBorder(vertexHelper: VertexHelper) {
+        glTranslated(radius.toDouble(), radius.toDouble(), 0.0)
+        drawCircleFilled(vertexHelper, radius = radius.toDouble(), color = backgroundColor)
+        drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = primaryColor)
+        glRotatef(mc.player.rotationYaw + 180, 0f, 0f, -1f)
+    }
+
+    private fun drawNewChunks(vertexHelper: VertexHelper) {
+        val playerOffset = Vec2d((mc.player.posX - (mc.player.chunkCoordX shl 4)), (mc.player.posZ - (mc.player.chunkCoordZ shl 4)))
+        val chunkDist = (radius * radarScale).toInt() shr 4
+        for (chunkX in -chunkDist..chunkDist) {
+            for (chunkZ in -chunkDist..chunkDist) {
+                val pos0 = getChunkPos(chunkX, chunkZ, playerOffset)
+                val pos1 = getChunkPos(chunkX + 1, chunkZ + 1, playerOffset)
+
+                if (squareInRadius(pos0, pos1)) {
+                    val chunk = mc.world.getChunk(mc.player.chunkCoordX + chunkX, mc.player.chunkCoordZ + chunkZ)
+                    if (!chunk.isLoaded)
+                        drawRectFilled(vertexHelper, pos0, pos1, distantChunkColor)
+                    drawRectOutline(vertexHelper, pos0, pos1, 0.3f, chunkGridColor)
+                }
+            }
+        }
+
+        for (chunk in NewChunks.chunks) {
+            val pos0 = getChunkPos(chunk.x - mc.player.chunkCoordX, chunk.z - mc.player.chunkCoordZ, playerOffset)
+            val pos1 = getChunkPos(chunk.x - mc.player.chunkCoordX + 1, chunk.z - mc.player.chunkCoordZ + 1, playerOffset)
+
+            if (squareInRadius(pos0, pos1)) {
+                drawRectFilled(vertexHelper, pos0, pos1, newChunkColor)
+            }
+        }
+    }
+
+    private fun drawEntities(vertexHelper: VertexHelper) {
+        drawCircleFilled(vertexHelper, radius = 1.0, color = primaryColor) //player marker
+        val player = arrayOf(players.value, true, true) //enable friends and sleeping
+        val mob = arrayOf(true, passive.value, neutral.value, hostile.value) //enable mobs
+
+        for (entity in EntityUtils.getTargetList(player, mob, invisible.value, radius * radarScale, ignoreSelf = true)) {
+            val entityPosDelta = entity.position.subtract(mc.player.position)
+            if (abs(entityPosDelta.y) > 30) continue
+            drawCircleFilled(vertexHelper, Vec2d(entityPosDelta.x.toDouble(), entityPosDelta.z.toDouble()).div(radarScale.toDouble()), 2.5 / radarScale, color = getColor(entity))
+        }
+    }
+
+    private fun drawLabels() {
+        FontRenderAdapter.drawString("Z+", -FontRenderAdapter.getStringWidth("+z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true, color = secondaryColor)
+        glRotatef(90f, 0f, 0f, 1f)
+        FontRenderAdapter.drawString("X-", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true, color = secondaryColor)
+        glRotatef(90f, 0f, 0f, 1f)
+        FontRenderAdapter.drawString("Z-", -FontRenderAdapter.getStringWidth("-z") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true, color = secondaryColor)
+        glRotatef(90f, 0f, 0f, 1f)
+        FontRenderAdapter.drawString("X+", -FontRenderAdapter.getStringWidth("+x") / 2f, radius - FontRenderAdapter.getFontHeight(), drawShadow = true, color = secondaryColor)
+    }
+
+    private fun getColor(entity: EntityLivingBase): ColorHolder {
+        return if (entity.isPassive || FriendManager.isFriend(entity.name)) { // green
+            ColorHolder(32, 224, 32, 224)
+        } else if (entity.isNeutral) { // yellow
+            ColorHolder(255, 240, 32)
+        } else { // red
+            ColorHolder(255, 32, 32)
+        }
+    }
+
+    // p2.x > p1.x and p2.y > p1.y is assumed
+    private fun squareInRadius(p1: Vec2d, p2: Vec2d): Boolean {
+        return if ((p1.x + p2.x) / 2 > 0) {
+            if ((p1.y + p2.y) / 2 > 0) {
+                p2.length()
+            } else {
+                Vec2d(p2.x, p1.y).length()
+            }
+        } else {
+            if ((p1.y + p2.y) / 2 > 0) {
+                Vec2d(p1.x, p2.y).length()
+            } else {
+                p1.length()
+            }
+        } < radius
+    }
+
+    private fun getChunkPos(x: Int, z: Int, playerOffset: Vec2d): Vec2d {
+        return Vec2d((x shl 4).toDouble(), (z shl 4).toDouble()).minus(playerOffset).div(radarScale.toDouble())
+    }
+}

--- a/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/world/Radar.kt
+++ b/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/world/Radar.kt
@@ -1,8 +1,10 @@
 package org.kamiblue.client.gui.hudgui.elements.world
 
 import net.minecraft.entity.EntityLivingBase
+import org.kamiblue.client.event.SafeClientEvent
 import org.kamiblue.client.gui.hudgui.HudElement
 import org.kamiblue.client.manager.managers.FriendManager
+import org.kamiblue.client.module.modules.client.GuiColors
 import org.kamiblue.client.module.modules.render.NewChunks
 import org.kamiblue.client.setting.GuiConfig.setting
 import org.kamiblue.client.util.EntityUtils
@@ -37,7 +39,6 @@ object Radar : HudElement(
     private val hostile = setting("Hostile Mobs", true)
     private val invisible = setting("Invisible Entities", true)
 
-    private val backgroundColor by setting("Background color", ColorHolder(28, 28, 28, 200), true)
     private val chunkGridColor by setting("Chunk grid color", ColorHolder(255, 0, 0, 100), true)
     private val distantChunkColor by setting("Distant chunk color", ColorHolder(100, 100, 100, 100), true, description = "Chunks that are not in render distance")
     private val newChunkColor by setting("New chunk color", ColorHolder(255, 0, 0, 100), true)
@@ -57,23 +58,23 @@ object Radar : HudElement(
         }
     }
 
-    private fun drawBorder(vertexHelper: VertexHelper) {
+    private fun SafeClientEvent.drawBorder(vertexHelper: VertexHelper) {
         glTranslated(radius.toDouble(), radius.toDouble(), 0.0)
-        drawCircleFilled(vertexHelper, radius = radius.toDouble(), color = backgroundColor)
+        drawCircleFilled(vertexHelper, radius = radius.toDouble(), color = GuiColors.backGround)
         drawCircleOutline(vertexHelper, radius = radius.toDouble(), lineWidth = 1.8f, color = primaryColor)
-        glRotatef(mc.player.rotationYaw + 180, 0f, 0f, -1f)
+        glRotatef(player.rotationYaw + 180, 0f, 0f, -1f)
     }
 
-    private fun drawNewChunks(vertexHelper: VertexHelper) {
-        val playerOffset = Vec2d((mc.player.posX - (mc.player.chunkCoordX shl 4)), (mc.player.posZ - (mc.player.chunkCoordZ shl 4)))
+    private fun SafeClientEvent.drawNewChunks(vertexHelper: VertexHelper) {
+        val playerOffset = Vec2d((player.posX - (player.chunkCoordX shl 4)), (player.posZ - (player.chunkCoordZ shl 4)))
         val chunkDist = (radius * radarScale).toInt() shr 4
         for (chunkX in -chunkDist..chunkDist) {
             for (chunkZ in -chunkDist..chunkDist) {
                 val pos0 = getChunkPos(chunkX, chunkZ, playerOffset)
                 val pos1 = getChunkPos(chunkX + 1, chunkZ + 1, playerOffset)
 
-                if (squareInRadius(pos0, pos1)) {
-                    val chunk = mc.world.getChunk(mc.player.chunkCoordX + chunkX, mc.player.chunkCoordZ + chunkZ)
+                if (isSquareInRadius(pos0, pos1)) {
+                    val chunk = world.getChunk(player.chunkCoordX + chunkX, player.chunkCoordZ + chunkZ)
                     if (!chunk.isLoaded)
                         drawRectFilled(vertexHelper, pos0, pos1, distantChunkColor)
                     drawRectOutline(vertexHelper, pos0, pos1, 0.3f, chunkGridColor)
@@ -82,22 +83,22 @@ object Radar : HudElement(
         }
 
         for (chunk in NewChunks.chunks) {
-            val pos0 = getChunkPos(chunk.x - mc.player.chunkCoordX, chunk.z - mc.player.chunkCoordZ, playerOffset)
-            val pos1 = getChunkPos(chunk.x - mc.player.chunkCoordX + 1, chunk.z - mc.player.chunkCoordZ + 1, playerOffset)
+            val pos0 = getChunkPos(chunk.x - player.chunkCoordX, chunk.z - player.chunkCoordZ, playerOffset)
+            val pos1 = getChunkPos(chunk.x - player.chunkCoordX + 1, chunk.z - player.chunkCoordZ + 1, playerOffset)
 
-            if (squareInRadius(pos0, pos1)) {
+            if (isSquareInRadius(pos0, pos1)) {
                 drawRectFilled(vertexHelper, pos0, pos1, newChunkColor)
             }
         }
     }
 
-    private fun drawEntities(vertexHelper: VertexHelper) {
+    private fun SafeClientEvent.drawEntities(vertexHelper: VertexHelper) {
         drawCircleFilled(vertexHelper, radius = 1.0, color = primaryColor) //player marker
-        val player = arrayOf(players.value, true, true) //enable friends and sleeping
-        val mob = arrayOf(true, passive.value, neutral.value, hostile.value) //enable mobs
 
-        for (entity in EntityUtils.getTargetList(player, mob, invisible.value, radius * radarScale, ignoreSelf = true)) {
-            val entityPosDelta = entity.position.subtract(mc.player.position)
+        val playerTargets = arrayOf(players.value, true, true) //enable friends and sleeping
+        val mobTargets = arrayOf(true, passive.value, neutral.value, hostile.value) //enable mobs
+        for (entity in EntityUtils.getTargetList(playerTargets, mobTargets, invisible.value, radius * radarScale, ignoreSelf = true)) {
+            val entityPosDelta = entity.position.subtract(player.position)
             if (abs(entityPosDelta.y) > 30) continue
             drawCircleFilled(vertexHelper, Vec2d(entityPosDelta.x.toDouble(), entityPosDelta.z.toDouble()).div(radarScale.toDouble()), 2.5 / radarScale, color = getColor(entity))
         }
@@ -124,7 +125,7 @@ object Radar : HudElement(
     }
 
     // p2.x > p1.x and p2.y > p1.y is assumed
-    private fun squareInRadius(p1: Vec2d, p2: Vec2d): Boolean {
+    private fun isSquareInRadius(p1: Vec2d, p2: Vec2d): Boolean {
         return if ((p1.x + p2.x) / 2 > 0) {
             if ((p1.y + p2.y) / 2 > 0) {
                 p2.length()

--- a/src/main/kotlin/org/kamiblue/client/module/modules/render/NewChunks.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/render/NewChunks.kt
@@ -111,6 +111,7 @@ internal object NewChunks : Module(
 
             val playerOffset = Vec2d((player.posX - (player.chunkCoordX shl 4)), (player.posZ - (player.chunkCoordZ shl 4)))
             val chunkDist = (it.radius * it.scale).toInt() shr 4
+
             for (chunkX in -chunkDist..chunkDist) {
                 for (chunkZ in -chunkDist..chunkDist) {
                     val pos0 = getChunkPos(chunkX, chunkZ, playerOffset, it.scale)
@@ -118,10 +119,14 @@ internal object NewChunks : Module(
 
                     if (isSquareInRadius(pos0, pos1, it.radius)) {
                         val chunk = world.getChunk(player.chunkCoordX + chunkX, player.chunkCoordZ + chunkZ)
-                        val isCachedChunk = BaritoneUtils.primary?.worldProvider?.currentWorld?.cachedWorld?.isCached((player.chunkCoordX + chunkX) shl 4, (player.chunkCoordZ + chunkZ) shl 4)
-                            ?: false
-                        if (!chunk.isLoaded && !isCachedChunk)
+                        val isCachedChunk =
+                            BaritoneUtils.primary?.worldProvider?.currentWorld?.cachedWorld?.isCached(
+                                (player.chunkCoordX + chunkX) shl 4, (player.chunkCoordZ + chunkZ) shl 4
+                            ) ?: false
+
+                        if (!chunk.isLoaded && !isCachedChunk) {
                             RenderUtils2D.drawRectFilled(it.vertexHelper, pos0, pos1, distantChunkColor)
+                        }
                         RenderUtils2D.drawRectOutline(it.vertexHelper, pos0, pos1, 0.3f, chunkGridColor)
                     }
                 }

--- a/src/main/kotlin/org/kamiblue/client/module/modules/render/NewChunks.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/render/NewChunks.kt
@@ -37,10 +37,10 @@ internal object NewChunks : Module(
     category = Category.RENDER
 ) {
     private val relative by setting("Relative", false, description = "Renders the chunks at relative Y level to player")
-    private val renderMode = setting("RenderMode", RenderMode.BOTH)
-    private val chunkGridColor by setting("Radar Chunk grid color", ColorHolder(255, 0, 0, 100), true, { renderMode.value != RenderMode.WORLD })
-    private val distantChunkColor by setting("Radar Distant chunk color", ColorHolder(100, 100, 100, 100), true, { renderMode.value != RenderMode.WORLD }, "Chunks that are not in render distance and not in baritone cache")
-    private val newChunkColor by setting("Radar New chunk color", ColorHolder(255, 0, 0, 100), true, { renderMode.value != RenderMode.WORLD })
+    private val renderMode = setting("Render Mode", RenderMode.BOTH)
+    private val chunkGridColor by setting("Grid Color", ColorHolder(255, 0, 0, 100), true, { renderMode.value != RenderMode.WORLD })
+    private val distantChunkColor by setting("Distant Chunk Color", ColorHolder(100, 100, 100, 100), true, { renderMode.value != RenderMode.WORLD }, "Chunks that are not in render distance and not in baritone cache")
+    private val newChunkColor by setting("New Chunk Color", ColorHolder(255, 0, 0, 100), true, { renderMode.value != RenderMode.WORLD })
     private val yOffset by setting("Y Offset", 0, -256..256, 4, fineStep = 1, description = "Render offset in Y axis")
     private val color by setting("Color", ColorHolder(255, 64, 64, 200), description = "Highlighting color")
     private val thickness by setting("Thickness", 1.5f, 0.1f..4.0f, 0.1f, description = "Thickness of the highlighting square")
@@ -164,19 +164,9 @@ internal object NewChunks : Module(
 
     // p2.x > p1.x and p2.y > p1.y is assumed
     private fun isSquareInRadius(p1: Vec2d, p2: Vec2d, radius: Float): Boolean {
-        return if ((p1.x + p2.x) / 2 > 0) {
-            if ((p1.y + p2.y) / 2 > 0) {
-                p2.length()
-            } else {
-                Vec2d(p2.x, p1.y).length()
-            }
-        } else {
-            if ((p1.y + p2.y) / 2 > 0) {
-                Vec2d(p1.x, p2.y).length()
-            } else {
-                p1.length()
-            }
-        } < radius
+        val x = if (p1.x + p2.x > 0) p2.x else p1.x
+        val y = if (p1.y + p2.y > 0) p2.y else p1.y
+        return Vec2d(x, y).length() < radius
     }
 
     private fun getChunkPos(x: Int, z: Int, playerOffset: Vec2d, scale: Float): Vec2d {

--- a/src/main/kotlin/org/kamiblue/client/module/modules/render/NewChunks.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/render/NewChunks.kt
@@ -33,6 +33,7 @@ internal object NewChunks : Module(
     category = Category.RENDER
 ) {
     private val relative by setting("Relative", false, description = "Renders the chunks at relative Y level to player")
+    val renderMode = setting("RenderMode", RenderMode.BOTH)
     private val yOffset by setting("Y Offset", 0, -256..256, 4, fineStep = 1, description = "Render offset in Y axis")
     private val color by setting("Color", ColorHolder(255, 64, 64, 200), description = "Highlighting color")
     private val thickness by setting("Thickness", 1.5f, 0.1f..4.0f, 0.1f, description = "Thickness of the highlighting square")
@@ -46,8 +47,12 @@ internal object NewChunks : Module(
         NEVER, UNLOAD, MAX_NUMBER
     }
 
+    enum class RenderMode {
+        WORLD, RADAR, BOTH
+    }
+
     private val timer = TickTimer(TimeUnit.MINUTES)
-    private val chunks = LinkedHashSet<ChunkPos>()
+    val chunks = LinkedHashSet<ChunkPos>()
 
     init {
         onEnable {
@@ -70,6 +75,8 @@ internal object NewChunks : Module(
         }
 
         safeListener<RenderWorldEvent> {
+            if (renderMode.value == RenderMode.RADAR) return@safeListener
+
             val y = yOffset.toDouble() + if (relative) getInterpolatedPos(player, KamiTessellator.pTicks()).y else 0.0
 
             glLineWidth(thickness)


### PR DESCRIPTION
This pull adds back the Radar to the new gui.
In addition several options are added:

- Scale of the radar
- Toggles for players, passive, neutral, hostile and invisible entities
- Background, grid, new and distant chunk color

The border and labels use the primary and secondary color of the component.
Uses EntityUtils.getTargetList to reduce duplicate code.
The setting to enable rendering of new chunks is in the newchunk module, because having a rendermode enum there also allows to only render new chunks in the radar.
