### PR TITLE
[fix] Stutter when leaving Freecam

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/TeleportLogger.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/TeleportLogger.kt
@@ -5,6 +5,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent
 import org.kamiblue.client.manager.managers.WaypointManager
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module
+import org.kamiblue.client.util.EntityUtils.isFakeOrSelf
 import org.kamiblue.client.util.text.MessageSendHelper
 import org.kamiblue.client.util.threads.safeListener
 import org.kamiblue.commons.utils.MathUtils
@@ -25,7 +26,7 @@ internal object TeleportLogger : Module(
     init {
         safeListener<TickEvent.ClientTickEvent> {
             for (worldPlayer in world.playerEntities) {
-                if (worldPlayer == player) continue
+                if (worldPlayer.isFakeOrSelf) continue
 
                 /* 8 chunk render distance * 16 */
                 if (remove.value && worldPlayer.getDistance(player) < 128) {

--- a/src/main/kotlin/org/kamiblue/client/module/modules/player/Freecam.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/player/Freecam.kt
@@ -224,7 +224,6 @@ internal object Freecam : Module(
             onMainThreadSafe {
                 world.removeEntityFromWorld(ENTITY_ID)
                 mc.renderViewEntity = player
-                mc.renderGlobal.loadRenderers()
                 if (prevThirdPersonViewSetting != -1) mc.gameSettings.thirdPersonView = prevThirdPersonViewSetting
             }
         }


### PR DESCRIPTION
I checked with #1759 and was not able to reproduce the issue after removing loadRenderers.

This problem is exaggerated when we call the loadRenderers with OptiFine added.

We do not need to reload the entire rendering pipeline every time we leave FreeCam.

If we still encounter the issue, I would much rather block unloading chunks from the graphics pipeline and check to make sure that works with OptiFine.

I believe some hints can be seen at RenderGlobal.stopChunkUpdates()

EDIT: Fixed wording since I was more talking about the specific usage on exit. The rest of the PR looks valid and fixed a few rendering problems.