### PR TITLE
[fix] Disable Strafe when in or above water

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/movement/Strafe.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/movement/Strafe.kt
@@ -12,6 +12,7 @@ import org.kamiblue.client.util.BaritoneUtils
 import org.kamiblue.client.util.MovementUtils
 import org.kamiblue.client.util.MovementUtils.applySpeedPotionEffects
 import org.kamiblue.client.util.MovementUtils.calcMoveYaw
+import org.kamiblue.client.util.MovementUtils.isInOrAboveLiquid
 import org.kamiblue.client.util.MovementUtils.setSpeed
 import org.kamiblue.client.util.MovementUtils.speed
 import org.kamiblue.client.util.TickTimer
@@ -71,7 +72,7 @@ internal object Strafe : Module(
                 return@safeListener
             }
 
-            setSpeed(getSpeed())
+            if (!player.collidedHorizontally) setSpeed(getSpeed())
 
             if (airSpeedBoost) player.jumpMovementFactor = 0.029f
             if (timerBoost) mc.timer.tickLength = 45.87155914306640625f
@@ -92,6 +93,7 @@ internal object Strafe : Module(
         && !player.isElytraFlying
         && (!onHoldingSprint || mc.gameSettings.keyBindSprint.isKeyDown)
         && MovementUtils.isInputting
+        && !(player.isInOrAboveLiquid || player.isInWeb)
 
     private fun SafeClientEvent.jump() {
         if (player.onGround && jumpTicks <= 0) {
@@ -135,5 +137,5 @@ internal object Strafe : Module(
     }
 
     private val SafeClientEvent.shouldBoostGroundSpeed
-        get() = groundSpeedBoost && player.onGround && !(player.isInWater || player.isInWeb)
+        get() = groundSpeedBoost && player.onGround
 }

--- a/src/main/kotlin/org/kamiblue/client/module/modules/movement/Strafe.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/movement/Strafe.kt
@@ -9,10 +9,10 @@ import org.kamiblue.client.mixin.extension.timer
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module
 import org.kamiblue.client.util.BaritoneUtils
+import org.kamiblue.client.util.EntityUtils.isInOrAboveLiquid
 import org.kamiblue.client.util.MovementUtils
 import org.kamiblue.client.util.MovementUtils.applySpeedPotionEffects
 import org.kamiblue.client.util.MovementUtils.calcMoveYaw
-import org.kamiblue.client.util.MovementUtils.isInOrAboveLiquid
 import org.kamiblue.client.util.MovementUtils.setSpeed
 import org.kamiblue.client.util.MovementUtils.speed
 import org.kamiblue.client.util.TickTimer

--- a/src/main/kotlin/org/kamiblue/client/util/EntityUtils.kt
+++ b/src/main/kotlin/org/kamiblue/client/util/EntityUtils.kt
@@ -38,6 +38,8 @@ object EntityUtils {
 
     val Entity.isHostile get() = isMobAggressive(this)
 
+    val Entity.isInOrAboveLiquid get() = world.containsAnyLiquid(entityBoundingBox.grow(0.0, -1.0, 0.0).shrink(0.001))
+
     val EntityPlayer.isFakeOrSelf get() = this == mc.player || this == mc.renderViewEntity || this.entityId < 0
 
     private fun isNeutralMob(entity: Entity) = entity is EntityPigZombie

--- a/src/main/kotlin/org/kamiblue/client/util/MovementUtils.kt
+++ b/src/main/kotlin/org/kamiblue/client/util/MovementUtils.kt
@@ -1,5 +1,6 @@
 package org.kamiblue.client.util
 
+import net.minecraft.block.material.Material
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.Entity
 import net.minecraft.init.MobEffects
@@ -19,6 +20,7 @@ object MovementUtils {
     val Entity.isMoving get() = speed > 0.0001
     val Entity.speed get() = hypot(motionX, motionZ)
     val Entity.realSpeed get() = hypot(posX - prevPosX, posZ - prevPosZ)
+    val Entity.isInOrAboveLiquid get() =  world.containsAnyLiquid(entityBoundingBox.grow(0.0, -1.0, 0.0).shrink(0.001))
 
     /* totally not taken from elytrafly */
     fun SafeClientEvent.calcMoveYaw(yawIn: Float = mc.player.rotationYaw, moveForward: Float = roundedForward, moveString: Float = roundedStrafing): Double {

--- a/src/main/kotlin/org/kamiblue/client/util/MovementUtils.kt
+++ b/src/main/kotlin/org/kamiblue/client/util/MovementUtils.kt
@@ -1,6 +1,5 @@
 package org.kamiblue.client.util
 
-import net.minecraft.block.material.Material
 import net.minecraft.client.Minecraft
 import net.minecraft.entity.Entity
 import net.minecraft.init.MobEffects
@@ -20,7 +19,6 @@ object MovementUtils {
     val Entity.isMoving get() = speed > 0.0001
     val Entity.speed get() = hypot(motionX, motionZ)
     val Entity.realSpeed get() = hypot(posX - prevPosX, posZ - prevPosZ)
-    val Entity.isInOrAboveLiquid get() =  world.containsAnyLiquid(entityBoundingBox.grow(0.0, -1.0, 0.0).shrink(0.001))
 
     /* totally not taken from elytrafly */
     fun SafeClientEvent.calcMoveYaw(yawIn: Float = mc.player.rotationYaw, moveForward: Float = roundedForward, moveString: Float = roundedStrafing): Double {


### PR DESCRIPTION
We should add a Water Speed or generic speed module for water movement controls.

For now, remove it from strafe due to default NCP checks triggering on this easily.
