### PR TITLE
[fix] wrong message being displayed when adding friends.

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/MidClickFriends.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/MidClickFriends.kt
@@ -43,8 +43,8 @@ internal object MidClickFriends : Module(
 
     private fun add(name: String) {
         defaultScope.launch {
-            if (FriendManager.addFriend(name)) MessageSendHelper.sendChatMessage("Failed to find UUID of $name")
-            else MessageSendHelper.sendChatMessage("&b$name&r has been friended.")
+            if (FriendManager.addFriend(name)) MessageSendHelper.sendChatMessage("&b$name&r has been friended.")
+            else MessageSendHelper.sendChatMessage("Failed to find UUID of $name")
         }
     }
 }


### PR DESCRIPTION
uh, how did this happen.

It was printing the wrong message, if it could find the uuid it said it can't, and if it can't is said it can!!!
