### PR TITLE
[enhancement] useIR for Kotlin compiling to use the beta backend.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ sourceSets.main.java {
 
 compileKotlin {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.useIR = true
 }
 
 compileJava {


### PR DESCRIPTION
This is coming in Kotlin 1.5.0 and we should shake out the bugs the best we can.

I can make this a gradle.properties file change to make it easily changed with build scripts.

https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/

inb4 xiaro blocks it
