### PR TITLE
fix: set command printing incorrect value

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/command/commands/SetCommand.kt
+++ b/src/main/kotlin/org/kamiblue/client/command/commands/SetCommand.kt
@@ -158,7 +158,7 @@ object SetCommand : ClientCommand(
 
         try {
             setting.setValue(value)
-            MessageSendHelper.sendChatMessage("Set ${formatValue(setting.name)} to ${formatValue(value)}.")
+            MessageSendHelper.sendChatMessage("Set ${formatValue(setting.name)} to ${formatValue(setting.value)}.")
         } catch (e: Exception) {
             MessageSendHelper.sendChatMessage("Unable to set value! ${TextFormatting.RED format e.message.toString()}")
             KamiMod.LOG.info("Unable to set value!", e)


### PR DESCRIPTION
Print the actual value of the setting instead of the value that is attempting to be set. This used to only go wrong when the requested value is out of the possible range.
