### PR TITLE
[new] Add Parkour

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/movement/Parkour.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/movement/Parkour.kt
@@ -1,0 +1,21 @@
+package org.kamiblue.client.module.modules.movement
+
+import net.minecraftforge.fml.common.gameevent.TickEvent
+import org.kamiblue.client.module.Category
+import org.kamiblue.client.module.Module
+import org.kamiblue.client.util.threads.safeListener
+
+
+internal object Parkour : Module(
+    name = "Parkour",
+    description = "Jump at the edge of blocks",
+    category = Category.MOVEMENT
+) {
+    init {
+        safeListener<TickEvent.ClientTickEvent> {
+            if(Companion.mc.player.onGround &&
+            !Companion.mc.player.isSneaking &&
+            Companion.mc.world.getCollisionBoxes(Companion.mc.player, Companion.mc.player.entityBoundingBox.offset(0.0, -0.5, 0.0).expand(-0.001, 0.0, -0.001)).isEmpty())
+            Companion.mc.player.jump() }
+        }
+    }


### PR DESCRIPTION
**Describe the pull**
Parkour is a module that jumps when you reach the edge of a block, to allow perfect jumps, such as Parkour jumps.

**Describe how this pull is helpful**
Satisfies #1273 

**Additional context**
Awful video. my computer was running hot, but it shows the module.

https://user-images.githubusercontent.com/53945697/112353966-a376e200-8ca2-11eb-9922-9b85302888bc.mp4


