### PR TITLE
impr: Custom AntiAFK AutoReply

### DIFF
--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/AntiAFK.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/AntiAFK.kt
@@ -34,7 +34,7 @@ internal object AntiAFK : Module(
     private val delay by setting("Action Delay", 50, 5..100, 5)
     private val variation by setting("Variation", 25, 0..50, 5)
     private val autoReply by setting("Auto Reply", true)
-    private val replyMessage by setting("Reply Message", "I am currently AFK and using KAMI Blue!", { autoReply })
+    private val replyMessage by setting("Reply Message", "I am AFK with KAMI Blue!", { autoReply })
     private val swing = setting("Swing", true)
     private val jump = setting("Jump", true)
     private val turn = setting("Turn", true)

--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/AntiAFK.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/AntiAFK.kt
@@ -34,6 +34,7 @@ internal object AntiAFK : Module(
     private val delay by setting("Action Delay", 50, 5..100, 5)
     private val variation by setting("Variation", 25, 0..50, 5)
     private val autoReply by setting("Auto Reply", true)
+    private val replyMessage by setting("Reply Message", "I am currently AFK and using KAMI Blue!", { autoReply })
     private val swing = setting("Swing", true)
     private val jump = setting("Jump", true)
     private val turn = setting("Turn", true)
@@ -86,7 +87,7 @@ internal object AntiAFK : Module(
         listener<PacketEvent.Receive> {
             if (!autoReply || it.packet !is SPacketChat) return@listener
             if (MessageDetection.Direct.RECEIVE detect it.packet.chatComponent.unformattedText) {
-                sendServerMessage("/r I am currently AFK and using KAMI Blue!")
+                sendServerMessage("/r $replyMessage")
             }
         }
 


### PR DESCRIPTION
**Describe the pull**
Allows the setting of a custom reply for AntiAFK autoreply.

**Describe how this pull is helpful**
Satisfies #2166

**Additional context**
Quick and simple fix, I had to shorten the default message because the default GUI size caused the default message to go off the side of the GUI element.
