### PR TITLE
refactor: convert some forge events to non forge events.

### DIFF
--- a/src/main/java/org/kamiblue/client/mixin/client/MixinMinecraft.java
+++ b/src/main/java/org/kamiblue/client/mixin/client/MixinMinecraft.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.common.ForgeHooks;
 import org.kamiblue.client.event.KamiEventBus;
 import org.kamiblue.client.event.events.GuiEvent;
+import org.kamiblue.client.event.events.InputEvent;
 import org.kamiblue.client.event.events.RunGameLoopEvent;
 import org.kamiblue.client.gui.mc.KamiGuiUpdateNotification;
 import org.kamiblue.client.manager.managers.HotbarManager;
@@ -165,6 +166,11 @@ public abstract class MixinMinecraft {
             Wrapper.getMinecraft().displayGuiScreen(new KamiGuiUpdateNotification());
         }
         PluginError.Companion.displayErrors();
+    }
+
+    @Inject(method = "runTickMouse", at = @At(value = "INVOKE", target = "Lorg/lwjgl/input/Mouse;getEventButton()I"))
+    public void mouseTick(CallbackInfo info) {
+        KamiEventBus.INSTANCE.post(new InputEvent.MouseInputEvent());
     }
 
 }

--- a/src/main/java/org/kamiblue/client/mixin/client/player/MixinEntityPlayerSP.java
+++ b/src/main/java/org/kamiblue/client/mixin/client/player/MixinEntityPlayerSP.java
@@ -10,10 +10,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.network.play.client.CPacketEntityAction;
 import net.minecraft.network.play.client.CPacketPlayer;
+import net.minecraft.util.MovementInput;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IInteractionObject;
 import net.minecraft.world.World;
 import org.kamiblue.client.event.KamiEventBus;
+import org.kamiblue.client.event.events.InputUpdateEvent;
 import org.kamiblue.client.event.events.OnUpdateWalkingPlayerEvent;
 import org.kamiblue.client.event.events.PlayerMoveEvent;
 import org.kamiblue.client.gui.mc.KamiGuiBeacon;
@@ -49,6 +51,7 @@ public abstract class MixinEntityPlayerSP extends EntityPlayer {
     @Shadow private boolean serverSneakState;
     @Shadow private boolean prevOnGround;
     @Shadow private boolean autoJumpEnabled;
+    @Shadow public MovementInput movementInput;
 
     @Shadow protected abstract boolean isCurrentViewEntity();
     @Shadow protected abstract void updateAutoJump(float p_189810_1_, float p_189810_2_);
@@ -234,5 +237,10 @@ public abstract class MixinEntityPlayerSP extends EntityPlayer {
         double pitchDiff = rotation.getY() - this.lastReportedPitch;
 
         return yawDiff != 0.0D || pitchDiff != 0.0D;
+    }
+
+    @Inject(method = "onLivingUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/MovementInput;updatePlayerMoveState()V", shift = At.Shift.AFTER))
+    public void onPlayerMoveStateUpdate(CallbackInfo ci) {
+        KamiEventBus.INSTANCE.post(new InputUpdateEvent(this, movementInput));
     }
 }

--- a/src/main/kotlin/org/kamiblue/client/event/ForgeEventProcessor.kt
+++ b/src/main/kotlin/org/kamiblue/client/event/ForgeEventProcessor.kt
@@ -14,7 +14,6 @@ import org.kamiblue.client.event.events.BaritoneCommandEvent
 import org.kamiblue.client.event.events.ConnectionEvent
 import org.kamiblue.client.event.events.RenderWorldEvent
 import org.kamiblue.client.event.events.ResolutionUpdateEvent
-import org.kamiblue.client.gui.GuiManager
 import org.kamiblue.client.gui.mc.KamiGuiChat
 import org.kamiblue.client.module.ModuleManager
 import org.kamiblue.client.util.Wrapper
@@ -96,17 +95,7 @@ internal object ForgeEventProcessor {
     }
 
     @SubscribeEvent
-    fun onEventMouse(event: InputEvent.MouseInputEvent) {
-        KamiEventBus.post(event)
-    }
-
-    @SubscribeEvent
     fun onChunkLoaded(event: ChunkEvent.Unload) {
-        KamiEventBus.post(event)
-    }
-
-    @SubscribeEvent
-    fun onInputUpdate(event: InputUpdateEvent) {
         KamiEventBus.post(event)
     }
 

--- a/src/main/kotlin/org/kamiblue/client/event/events/InputEvent.kt
+++ b/src/main/kotlin/org/kamiblue/client/event/events/InputEvent.kt
@@ -1,0 +1,9 @@
+package org.kamiblue.client.event.events
+
+import org.kamiblue.client.event.Event
+
+class InputEvent {
+
+    class MouseInputEvent : Event
+    class KeyboardInputEvent : Event
+}

--- a/src/main/kotlin/org/kamiblue/client/event/events/InputUpdateEvent.kt
+++ b/src/main/kotlin/org/kamiblue/client/event/events/InputUpdateEvent.kt
@@ -1,0 +1,6 @@
+package org.kamiblue.client.event.events
+
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.util.MovementInput
+
+class InputUpdateEvent(val player: EntityPlayer, val movementInput: MovementInput)

--- a/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/misc/CPS.kt
+++ b/src/main/kotlin/org/kamiblue/client/gui/hudgui/elements/misc/CPS.kt
@@ -1,7 +1,7 @@
 package org.kamiblue.client.gui.hudgui.elements.misc
 
-import net.minecraftforge.fml.common.gameevent.InputEvent
 import org.kamiblue.client.event.SafeClientEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.event.events.RunGameLoopEvent
 import org.kamiblue.client.gui.hudgui.LabelHud
 import org.kamiblue.client.util.TickTimer

--- a/src/main/kotlin/org/kamiblue/client/module/modules/combat/HoleSnap.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/combat/HoleSnap.kt
@@ -4,8 +4,8 @@ import net.minecraft.network.play.server.SPacketPlayerPosLook
 import net.minecraft.util.MovementInputFromOptions
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Vec3d
-import net.minecraftforge.client.event.InputUpdateEvent
 import org.kamiblue.client.event.SafeClientEvent
+import org.kamiblue.client.event.events.InputUpdateEvent
 import org.kamiblue.client.event.events.PacketEvent
 import org.kamiblue.client.event.events.PlayerMoveEvent
 import org.kamiblue.client.event.events.RenderWorldEvent

--- a/src/main/kotlin/org/kamiblue/client/module/modules/combat/MidClickPearl.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/combat/MidClickPearl.kt
@@ -3,8 +3,8 @@ package org.kamiblue.client.module.modules.combat
 import net.minecraft.init.Items
 import net.minecraft.util.EnumHand
 import net.minecraft.util.math.RayTraceResult.Type
-import net.minecraftforge.fml.common.gameevent.InputEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module
 import org.kamiblue.client.util.items.firstItem

--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/AntiAFK.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/AntiAFK.kt
@@ -4,10 +4,10 @@ import baritone.api.pathing.goals.GoalXZ
 import net.minecraft.network.play.server.SPacketChat
 import net.minecraft.util.EnumHand
 import net.minecraft.util.math.BlockPos
-import net.minecraftforge.fml.common.gameevent.InputEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import org.kamiblue.client.event.SafeClientEvent
 import org.kamiblue.client.event.events.BaritoneSettingsInitEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.event.events.PacketEvent
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module
@@ -97,7 +97,7 @@ internal object AntiAFK : Module(
             }
         }
 
-        listener<InputEvent.KeyInputEvent> {
+        listener<net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent> {
             if (inputTimeout > 0 && isPressing()) {
                 startPos = null
                 inputTimer.reset()

--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/BlockData.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/BlockData.kt
@@ -3,7 +3,7 @@ package org.kamiblue.client.module.modules.misc
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.RayTraceResult
-import net.minecraftforge.fml.common.gameevent.InputEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module
 import org.kamiblue.client.util.TickTimer

--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/EntityTools.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/EntityTools.kt
@@ -3,7 +3,7 @@ package org.kamiblue.client.module.modules.misc
 import net.minecraft.entity.Entity
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.math.RayTraceResult
-import net.minecraftforge.fml.common.gameevent.InputEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module
 import org.kamiblue.client.util.TickTimer

--- a/src/main/kotlin/org/kamiblue/client/module/modules/misc/MidClickFriends.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/misc/MidClickFriends.kt
@@ -3,7 +3,7 @@ package org.kamiblue.client.module.modules.misc
 import kotlinx.coroutines.launch
 import net.minecraft.client.entity.EntityOtherPlayerMP
 import net.minecraft.util.math.RayTraceResult
-import net.minecraftforge.fml.common.gameevent.InputEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.manager.managers.FriendManager
 import org.kamiblue.client.module.Category
 import org.kamiblue.client.module.Module

--- a/src/main/kotlin/org/kamiblue/client/module/modules/movement/AutoWalk.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/movement/AutoWalk.kt
@@ -2,7 +2,7 @@ package org.kamiblue.client.module.modules.movement
 
 import baritone.api.pathing.goals.GoalXZ
 import net.minecraft.util.MovementInputFromOptions
-import net.minecraftforge.client.event.InputUpdateEvent
+import org.kamiblue.client.event.events.InputUpdateEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import org.kamiblue.client.event.SafeClientEvent
 import org.kamiblue.client.event.events.BaritoneCommandEvent

--- a/src/main/kotlin/org/kamiblue/client/module/modules/movement/InventoryMove.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/movement/InventoryMove.kt
@@ -5,7 +5,7 @@ import net.minecraft.client.gui.GuiRepair
 import net.minecraft.client.gui.GuiScreen
 import net.minecraft.client.gui.inventory.GuiEditSign
 import net.minecraft.util.MovementInputFromOptions
-import net.minecraftforge.client.event.InputUpdateEvent
+import org.kamiblue.client.event.events.InputUpdateEvent
 import org.kamiblue.client.KamiMod
 import org.kamiblue.client.gui.AbstractKamiGui
 import org.kamiblue.client.module.Category

--- a/src/main/kotlin/org/kamiblue/client/module/modules/movement/NoSlowDown.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/movement/NoSlowDown.kt
@@ -6,7 +6,7 @@ import net.minecraft.network.play.client.CPacketPlayer
 import net.minecraft.network.play.client.CPacketPlayerDigging
 import net.minecraft.network.play.client.CPacketPlayerDigging.Action
 import net.minecraft.util.EnumFacing
-import net.minecraftforge.client.event.InputUpdateEvent
+import org.kamiblue.client.event.events.InputUpdateEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import org.kamiblue.client.event.SafeClientEvent
 import org.kamiblue.client.event.events.PacketEvent

--- a/src/main/kotlin/org/kamiblue/client/module/modules/player/Freecam.kt
+++ b/src/main/kotlin/org/kamiblue/client/module/modules/player/Freecam.kt
@@ -14,11 +14,11 @@ import net.minecraft.util.MovementInputFromOptions
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.RayTraceResult
 import net.minecraft.util.math.Vec3d
-import net.minecraftforge.client.event.InputUpdateEvent
-import net.minecraftforge.fml.common.gameevent.InputEvent
+import org.kamiblue.client.event.events.InputUpdateEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent
 import org.kamiblue.client.event.SafeClientEvent
 import org.kamiblue.client.event.events.ConnectionEvent
+import org.kamiblue.client.event.events.InputEvent
 import org.kamiblue.client.event.events.PacketEvent
 import org.kamiblue.client.event.events.PlayerAttackEvent
 import org.kamiblue.client.module.Category
@@ -128,7 +128,7 @@ internal object Freecam : Module(
             if (it.entity == mc.player) it.cancel()
         }
 
-        safeListener<InputEvent.KeyInputEvent> {
+        safeListener<net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent> {
             // Force it to stay in first person lol
             if (mc.gameSettings.keyBindTogglePerspective.isKeyDown) mc.gameSettings.thirdPersonView = 2
         }


### PR DESCRIPTION
As per our [conversation on discord](https://discord.com/channels/573954110454366214/821815568394878976/822909394692866078), this removes the use of forge events MouseInputEvent and InputUpdateEvent.